### PR TITLE
Packaging of machine-emulator-tools as a docker image

### DIFF
--- a/packages/machine-emulator-tools/Dockerfile
+++ b/packages/machine-emulator-tools/Dockerfile
@@ -6,4 +6,6 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${VERSI
 RUN mkdir -p /tmp/machine-emulator-tools && tar -C /tmp/machine-emulator-tools -xzf /tmp/machine-emulator-tools.tar.gz
 
 FROM scratch as tools
-COPY --from=download /tmp/machine-emulator-tools/ /
+COPY --from=download /tmp/machine-emulator-tools/sbin/init /usr/sbin/init
+COPY --from=download /tmp/machine-emulator-tools/etc/hostname /etc/hostname
+COPY --from=download /tmp/machine-emulator-tools/opt/cartesi /opt/cartesi/

--- a/packages/machine-emulator-tools/Dockerfile
+++ b/packages/machine-emulator-tools/Dockerfile
@@ -1,0 +1,9 @@
+# download machine-emulator tools and create a scratch image the tar.gz contents at root
+FROM busybox as download
+ARG VERSION
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${VERSION}/machine-emulator-tools-v${VERSION}.tar.gz \
+    /tmp/machine-emulator-tools.tar.gz
+RUN mkdir -p /tmp/machine-emulator-tools && tar -C /tmp/machine-emulator-tools -xzf /tmp/machine-emulator-tools.tar.gz
+
+FROM scratch as tools
+COPY --from=download /tmp/machine-emulator-tools/ /

--- a/packages/machine-emulator-tools/README.md
+++ b/packages/machine-emulator-tools/README.md
@@ -1,0 +1,33 @@
+# Machine emulator tools packaging
+
+The [machine-emulator-tools](https://github.com/cartesi/machine-emulator-tools) is a set of tools that need to be installed in the root filesystem of a Cartesi DApp.
+
+It is currently distributed in binary format compiled for the `linux/riscv64` architecture and available as a `.tar.gz` file in the [GitHub releases](https://github.com/cartesi/machine-emulator-tools/releases).
+
+However the most convenient way to add this to the user application, which uses Docker as a build system, was to add a `COPY --from` directive, like the one below:
+
+```dockerfile
+COPY --from=cartesi/machine-emulator-tools:0.10.0 / /
+```
+
+While `cartesi` doesn't provide such image, Sunodo will provide the image under the `ghcr.io/sunodo` organization.
+
+So the application should include the following:
+
+```dockerfile
+COPY --from=sunodo/machine-emulator-tools:0.10.0-ubuntu22.04 / /
+```
+
+Only `ubuntu 22.04` is currently supported. We might add other distributions in the future.
+
+## Building the image
+
+To build and publish the images to the registry, you need to have the `docker` CLI installed and logged in to both `ghcr.io/sunodo` and `docker.io` registries.
+
+Then you can run the following command:
+
+```bash
+docker buildx bake --push --provenance=false
+```
+
+The `--provenance=false` is needed because of an [issue](https://github.com/docker/buildx/issues/1509#issuecomment-1378454396) with GHCR not handling well new docker images produced with provenance by default by BuildKit 0.11+.

--- a/packages/machine-emulator-tools/docker-bake.hcl
+++ b/packages/machine-emulator-tools/docker-bake.hcl
@@ -1,0 +1,25 @@
+
+group "default" {
+  targets = ["tools-0-10-0-ubuntu"]
+}
+
+target "tools-template" {
+  platforms = ["linux/riscv64"]
+}
+
+target "tools-0-10-0-ubuntu" {
+  inherits = ["tools-template"]
+  tags = [
+    "sunodo/machine-emulator-tools:0.10.0-jammy",
+    "sunodo/machine-emulator-tools:0.10.0-ubuntu22.04",
+    "sunodo/machine-emulator-tools:0.10-jammy",
+    "sunodo/machine-emulator-tools:0.10-ubuntu22.04",
+    "ghcr.io/sunodo/machine-emulator-tools:0.10.0-jammy",
+    "ghcr.io/sunodo/machine-emulator-tools:0.10.0-ubuntu22.04",
+    "ghcr.io/sunodo/machine-emulator-tools:0.10-jammy",
+    "ghcr.io/sunodo/machine-emulator-tools:0.10-ubuntu22.04"
+  ]
+  args = {
+    "VERSION" = "0.10.0"
+  }
+}


### PR DESCRIPTION
This packages a docker image from scratch with the contents of [machine-emulator-tools](https://github.com/cartesi/machine-emulator-tools) release.

The arch of the image is `linux/riscv64` and the intent is to be used by dapps Dockerfiles to add necessary files to the dapp, like so:

```
COPY --from sunodo/machine-emulator-tools / /
```

Eventually this could be published by Cartesi itself as part of their release process.

There is a fix to workaround a know bug of the location of the init script inside the package.

I already built and published the images to both DockerHub and GitHub