### PR TITLE
Update genext2fs with better size calculation

### DIFF
--- a/packages/toolchain/Dockerfile
+++ b/packages/toolchain/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:22.04 as genext2fs
 
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool
+apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libarchive-dev libtool
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -17,7 +17,7 @@ WORKDIR /usr/local/src
 RUN <<EOF
 curl -sL https://github.com/cartesi/genext2fs/archive/refs/heads/cartesi.tar.gz | tar --strip-components=1 -zxvf -
 ./autogen.sh
-./configure
+./configure --enable-libarchive
 make
 make install
 EOF

--- a/packages/toolchain/Dockerfile
+++ b/packages/toolchain/Dockerfile
@@ -15,7 +15,7 @@ EOF
 WORKDIR /usr/local/src
 
 RUN <<EOF
-curl -sL https://github.com/cartesi/genext2fs/archive/refs/heads/next.tar.gz | tar --strip-components=1 -zxvf -
+curl -sL https://github.com/cartesi/genext2fs/archive/refs/heads/cartesi.tar.gz | tar --strip-components=1 -zxvf -
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
This updates the genext2fs with changes that include `libarchive` for correct size calculation when generating from `tar`.

In a future PR we should use a tagged version instead of the `cartesi` moving branch.
And there are a few other things that should be fixed in the `genext2fs` fork:

- `-r` behavior is strange, like `-r +0` doesn't work
- fix the `--version` to print a version of our fork
- update `--help` with the new args