### PR TITLE
Mitigate permission problem on Linux

### DIFF
--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import fs from "fs-extra";
+import os from "os";
 import path from "path";
 import { execa } from "execa";
 import tmp from "tmp";
@@ -173,6 +174,19 @@ export default class BuildApplication extends Command {
         const tar = path.join(containerDir, tarName + ".tar");
         const ext2 = path.join(containerDir, tarName + ".ext2");
 
+        // su, variables to run container as current user
+        const user = os.userInfo();
+        const su = [
+            "--env",
+            `USER=${user.username}`,
+            "--env",
+            `GROUP=container-group-${user.gid}`,
+            "--env",
+            `UID=${user.uid}`,
+            "--env",
+            `GID=${user.gid}`,
+        ];
+
         // calculate extra size
         const blockSize = 4096;
         const extraBytes = bytes.parse(info.dataSize);
@@ -185,6 +199,7 @@ export default class BuildApplication extends Command {
                 "container",
                 "run",
                 "--rm",
+                ...su,
                 "--volume",
                 bind,
                 toolchainImage,
@@ -219,6 +234,19 @@ export default class BuildApplication extends Command {
         const driveLabel = "root"; // XXX: does this need to be customizable?
         const outDir = path.join(containerDir, name);
 
+        // su, variables to run container as current user
+        const user = os.userInfo();
+        const su = [
+            "--env",
+            `USER=${user.username}`,
+            "--env",
+            `GROUP=container-group-${user.gid}`,
+            "--env",
+            `UID=${user.uid}`,
+            "--env",
+            `GID=${user.gid}`,
+        ];
+
         // list of environment variables of docker image
         // XXX: we can't include all of them because cartesi-machine command has length limits
         const envs = info.env.filter((variable) => {
@@ -249,6 +277,7 @@ export default class BuildApplication extends Command {
                 "container",
                 "run",
                 "--rm",
+                ...su,
                 "--volume",
                 bind,
                 toolchainImage,

--- a/packages/toolchain/Dockerfile
+++ b/packages/toolchain/Dockerfile
@@ -6,20 +6,27 @@ ARG ROM_VERSION
 
 FROM ubuntu:22.04 as genext2fs
 
+WORKDIR /usr/local/src
 RUN <<EOF
 apt-get update
 apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libarchive-dev libtool
 rm -rf /var/lib/apt/lists/*
-EOF
-
-WORKDIR /usr/local/src
-
-RUN <<EOF
 curl -sL https://github.com/cartesi/genext2fs/archive/refs/heads/cartesi.tar.gz | tar --strip-components=1 -zxvf -
 ./autogen.sh
 ./configure --enable-libarchive
 make
 make install
+EOF
+
+FROM ubuntu:22.04 as su-exec
+
+WORKDIR /usr/local/src
+RUN <<EOF
+apt-get update
+apt-get install -y --no-install-recommends build-essential ca-certificates curl
+rm -rf /var/lib/apt/lists/*
+curl -sL https://github.com/ncopa/su-exec/archive/refs/tags/v0.2.tar.gz | tar --strip-components=1 -zxvf -
+make
 EOF
 
 # toolchain image
@@ -29,11 +36,16 @@ ARG LINUX_VERSION
 ARG LINUX_KERNEL_VERSION
 ARG ROM_VERSION
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --from=genext2fs /usr/local/bin/genext2fs /usr/bin/
+COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 
-ADD https://github.com/cartesi/image-kernel/releases/download/v$LINUX_VERSION/linux-$LINUX_KERNEL_VERSION.bin \
+ADD --chmod=644 \
+    https://github.com/cartesi/image-kernel/releases/download/v$LINUX_VERSION/linux-$LINUX_KERNEL_VERSION.bin \
     /opt/cartesi/share/images/linux.bin
-ADD https://github.com/cartesi/machine-emulator-rom/releases/download/v$ROM_VERSION/rom-v$ROM_VERSION.bin \
+ADD --chmod=644 \
+    https://github.com/cartesi/machine-emulator-rom/releases/download/v$ROM_VERSION/rom-v$ROM_VERSION.bin \
     /opt/cartesi/share/images/rom.bin
 
 WORKDIR /mnt
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/toolchain/docker-bake.hcl
+++ b/packages/toolchain/docker-bake.hcl
@@ -13,3 +13,13 @@ target "toolchain-0-14-0" {
   platforms = ["linux/amd64", "linux/arm64"]
   tags      = ["sunodo/toolchain:0.14.0", "ghcr.io/sunodo/toolchain:0.14.0"]
 }
+
+target "toolchain-devel" {
+  args = {
+    MACHINE_EMULATOR_VERSION = "0.13.0"
+    LINUX_VERSION            = "0.15.0"
+    LINUX_KERNEL_VERSION     = "5.15.63-ctsi-1"
+    ROM_VERSION              = "0.15.0"
+  }
+  tags      = ["sunodo/toolchain:devel"]
+}

--- a/packages/toolchain/entrypoint.sh
+++ b/packages/toolchain/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ -z "$GID" -o -z "$UID" -o -z "$USER" -o -z "$GROUP" ]; then
+    exec "$@"
+else
+  if [ ! $(getent group $GID) ]; then
+    if [ $(getent group $GROUP) ]; then
+      GROUP=container-group-$GID
+    fi
+    groupadd -g $GID $GROUP
+  else
+    GROUP=$(getent group $GID | cut -d: -f1)
+  fi
+  if [ ! $(getent passwd $UID) ]; then
+    if [ $(getent passwd $USER) ]; then
+      USER=container-user-$UID
+    fi
+    useradd -u $UID -g $GID -G $GROUP $USER
+  fi
+  USERNAME=$(id -nu $UID)
+  export HOME=/home/$USERNAME
+  mkdir -p $HOME
+  chown $UID:$GID $HOME
+
+  # Workaround for issue with su-exec tty ownership
+  # Should be removed once ticket https://github.com/ncopa/su-exec/issues/33
+  # is resolved, or alternative solution with reusing file descriptors is found
+  # Test if stdin is associated with a terminal
+  if [ -t 0 ]; then
+    chown $UID:$GID $(/usr/bin/tty)
+  fi
+
+  exec /usr/local/bin/su-exec $USERNAME "$@"
+fi


### PR DESCRIPTION
The behavior of Docker on Linux and on macOS is different in regards of file permissions.

On Linux the recommended installation procedure is to run the docker daemon as root.
So when you run a container it runs as root by default.

On macOS docker runs in a virtualized environment, and the process which manages the virtualization does not run as root.

This is an article that explains the problem in detail:
https://jtreminio.com/blog/running-docker-containers-as-current-host-user/

The changes in this PR:

1) creates a `sunodo:sunodo` user/group in the toolchain image, with a UID:GID of 1000:1000
2) UID and GID are build args, but default to 1000:1000, which I believe is the most common values in a desktop Linux user
3) creates a home directory `/home/sunodo` and use that instead of `/mnt`
4) changes the permissions of the downloaded machine files to allow read from `sunodo` user

To test this on Linux:

1) build the a `sunodo/toolchain:devel` image, by `cd packages/toolchain; docker buildx bake toolchain-level --load`
2) in a project change:

```diff
-LABEL io.cartesi.rollups.sdk_version=0.14.0
+LABEL io.cartesi.rollups.sdk_version=devel
```

3) run `sunodo build` and check the file permissions of `.sunodo/`



This solution is not bullet proof, as it uses fixed values for uid:gid (1000:1000).
As far I could research toolchain users would have to build the toolchain image on their machine, specifying the values coming from `id -u && id -g`.
This is not convenient. But it may be possible.