### PR TITLE
fix: using --iidfile instead of --metadata-file in buildx build

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1] 2023-04-27
+
+### Changed
+
+- Fix https://github.com/sunodo/sunodo/issues/34
+
+## [0.3.0] 2023-04-26
+
+### Added
+
+- First version using new web3 architecture
+- Initial version of `sunodo build`
+- Initial version of `sunodo clean`
+- Initial version of `sunodo shell`
+
+## [0.2.0] 2022-04-14
+
+### Added
+
+- First working version of CLI with deployed API
+ansactions
+
+## [0.1.0] 2023-03-31
+
+### Added
+
+- First prototype
+
+[0.3.1]: https://github.com/sunodo/sunodo/releases/tag/v0.3.1
+[0.3.0]: https://github.com/sunodo/sunodo/releases/tag/v0.3.0
+[0.2.0]: https://github.com/sunodo/sunodo/releases/tag/v0.2.0
+[0.1.0]: https://github.com/sunodo/sunodo/releases/tag/v0.1.0

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -25,7 +25,7 @@ $ npm install -g @sunodo/cli
 $ sunodo COMMAND
 running command...
 $ sunodo (--version)
-@sunodo/cli/0.3.0 darwin-arm64 node-v20.0.0
+@sunodo/cli/0.3.1 darwin-arm64 node-v20.0.0
 $ sunodo --help [COMMAND]
 USAGE
   $ sunodo COMMAND
@@ -86,7 +86,7 @@ FLAG DESCRIPTIONS
     machine is not the last stage, use this parameter to specify the target stage.
 ```
 
-_See code: [dist/commands/build.ts](https://github.com/sunodo/sunodo/blob/v0.3.0/dist/commands/build.ts)_
+_See code: [dist/commands/build.ts](https://github.com/sunodo/sunodo/blob/v0.3.1/dist/commands/build.ts)_
 
 ## `sunodo clean`
 
@@ -105,7 +105,7 @@ EXAMPLES
   $ sunodo clean
 ```
 
-_See code: [dist/commands/clean.ts](https://github.com/sunodo/sunodo/blob/v0.3.0/dist/commands/clean.ts)_
+_See code: [dist/commands/clean.ts](https://github.com/sunodo/sunodo/blob/v0.3.1/dist/commands/clean.ts)_
 
 ## `sunodo create NAME`
 
@@ -130,7 +130,7 @@ EXAMPLES
   $ sunodo create
 ```
 
-_See code: [dist/commands/create.ts](https://github.com/sunodo/sunodo/blob/v0.3.0/dist/commands/create.ts)_
+_See code: [dist/commands/create.ts](https://github.com/sunodo/sunodo/blob/v0.3.1/dist/commands/create.ts)_
 
 ## `sunodo help [COMMANDS]`
 
@@ -173,7 +173,7 @@ EXAMPLES
   $ sunodo shell
 ```
 
-_See code: [dist/commands/shell.ts](https://github.com/sunodo/sunodo/blob/v0.3.0/dist/commands/shell.ts)_
+_See code: [dist/commands/shell.ts](https://github.com/sunodo/sunodo/blob/v0.3.1/dist/commands/shell.ts)_
 
 ## `sunodo update [CHANNEL]`
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sunodo/cli",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Sunodo CLI",
     "author": "Danilo Tuler <tuler@pobox.com>",
     "bin": {

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -67,13 +67,14 @@ export default class BuildApplication extends Command {
      */
     private async buildDAppImage(options: ImageBuildOptions): Promise<string> {
         const buildResult = tmp.tmpNameSync();
+        this.debug(`building docker image and writing result to ${buildResult}`);
         const args = [
             "buildx",
             "build",
             "--load",
             "--build-arg",
             `NETWORK=${options.network}`,
-            "--metadata-file",
+            "--iidfile",
             buildResult,
         ];
         if (options.target) {
@@ -81,9 +82,7 @@ export default class BuildApplication extends Command {
         }
 
         await execa("docker", [...args, process.cwd()], { stdio: "inherit" });
-
-        const result = JSON.parse(fs.readFileSync(buildResult, "utf8"));
-        return result["containerimage.config.digest"].replace("sha256:", "");
+        return fs.readFileSync(buildResult, "utf8");
     }
 
     private async getImageInfo(image: string): Promise<ImageInfo> {


### PR DESCRIPTION
the format of the json produced by —metadata-file changes between versions of buildx

closes #34 