### PR TITLE
Anvil docker image

### DIFF
--- a/.github/workflows/anvil.yaml
+++ b/.github/workflows/anvil.yaml
@@ -1,0 +1,67 @@
+name: anvil
+on:
+    push:
+        branches:
+            - main
+        tags:
+            - v*
+    pull_request:
+        paths:
+            - .github/workflows/anvil.yaml
+            - packages/anvil/**
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+permissions:
+    contents: read
+    packages: write
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v4
+              with:
+                  images: |
+                      docker.io/sunodo/anvil,enable=${{ github.event_name != 'pull_request' }}
+                      ghcr.io/sunodo/anvil
+                  tags: |
+                      type=semver,pattern={{version}}
+                      type=edge
+                      type=ref,event=pr
+                  labels: |
+                      org.opencontainers.image.title=Sunodo anvil
+                      org.opencontainers.image.description=Sunodo anvil image with healthcheck
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v2
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Login to DockerHub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Build and push
+              uses: docker/bake-action@v3
+              with:
+                  workdir: packages/anvil
+                  files: |
+                      ./docker-bake.hcl
+                      ./docker-bake.platforms.hcl
+                      ${{ steps.meta.outputs.bake-file }}
+                  set: |
+                      *.cache-from=type=gha
+                      *.cache-to=type=gha,mode=max
+                  push: true

--- a/packages/anvil/Dockerfile
+++ b/packages/anvil/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker.io/docker/dockerfile:1.4
+FROM debian:bullseye-20230502-slim
+
+# install curl and jq (for healthcheck support)
+RUN <<EOF
+apt-get update
+DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends ca-certificates curl jq
+rm -rf /var/lib/apt/lists/*
+EOF
+
+# download pre-compiled binaries
+RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
+    tar -zx -C /usr/local/bin
+
+# healthcheck script using net_listening JSON-RPC method
+COPY eth_isready /usr/local/bin
+
+HEALTHCHECK CMD eth_isready
+
+ENTRYPOINT ["/usr/local/bin/anvil"]

--- a/packages/anvil/docker-bake.hcl
+++ b/packages/anvil/docker-bake.hcl
@@ -1,0 +1,7 @@
+target "docker-metadata-action" {}
+target "docker-platforms" {}
+
+target "default" {
+  inherits = ["docker-metadata-action", "docker-platforms"]
+  tags     = ["sunodo/anvil:devel"]
+}

--- a/packages/anvil/docker-bake.override.hcl
+++ b/packages/anvil/docker-bake.override.hcl
@@ -1,0 +1,3 @@
+target "default" {
+  tags = ["sunodo/anvil:devel"]
+}

--- a/packages/anvil/docker-bake.platforms.hcl
+++ b/packages/anvil/docker-bake.platforms.hcl
@@ -1,0 +1,6 @@
+target "docker-platforms" {
+    platforms = [
+        "linux/amd64",
+        "linux/arm64"
+    ]
+}

--- a/packages/anvil/eth_isready
+++ b/packages/anvil/eth_isready
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# https://ethereum.org/en/developers/docs/apis/json-rpc/#net_listening
+curl -X POST -s -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"net_listening","params":[]}' ${RPC_URL:-http://127.0.0.1:8545} | jq '.result'


### PR DESCRIPTION
This creates an image tagged `sunodo/anvil` that has [foundry binaries](https://github.com/foundry-rs/foundry) and also includes `curl` and `jq` that can be used for healthcheck.

The base image is debian, and this can set the baseline for later including anvil in the single container of the cartesi node.

The image is being built in the CI, for both `amd64` and `arm64` architectures.
