### PR TITLE
CLI Debian publishing

### DIFF
--- a/.changeset/hungry-ravens-relax.md
+++ b/.changeset/hungry-ravens-relax.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+add terraform module and CI for debian packaging and release process

--- a/.github/actions/cli-ci-setup/action.yaml
+++ b/.github/actions/cli-ci-setup/action.yaml
@@ -1,0 +1,35 @@
+name: cli CI setup
+description: 'Sets up the environment for jobs during cli CI workflow'
+
+runs:
+  using: composite
+  steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nsis p7zip-full awscli
+        shell: bash
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v3
+        with:
+            node-version: 20
+            cache: "yarn"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install dependencies
+        run: yarn install
+        shell: bash
+
+      - name: Build
+        run: yarn build --filter @sunodo/cli
+        shell: bash
+
+      - name: Install oclif
+        run: yarn global add oclif
+        shell: bash

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -23,31 +23,19 @@ concurrency:
 permissions:
     contents: read
     packages: write
+    id-token: write
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 jobs:
     build:
         runs-on: ubuntu-latest
-        env:
-            TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-            TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - name: Setup Node.js 20
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 20
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "yarn"
-
-            - name: Install Foundry
-              uses: foundry-rs/foundry-toolchain@v1
-
-            - name: Install dependencies
-              run: yarn install
-
             - name: Build
-              run: yarn build --filter @sunodo/cli
+              uses: './.github/actions/cli-ci-setup'
 
             - name: Publish
               if: ${{ inputs.release }}
@@ -55,3 +43,112 @@ jobs:
               run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    pack_upload_deb:
+          runs-on: ubuntu-latest
+          if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
+          steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup environment
+              uses: './.github/actions/cli-ci-setup'
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
+                  aws-region: ${{ secrets.AWS_REGION }}
+
+            - name: Install GPG key for debian package signing
+              id: gpg_key
+              uses: crazy-max/ghaction-import-gpg@v5
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+            - name: Build debian package
+              run: yarn oclif pack deb --root="./apps/cli"
+              env:
+                  SUNODO_DEB_KEY: ${{ steps.gpg_key.outputs.keyid }}
+
+            - name: Upload debian packages to Github artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: Packages-deb
+                  path: ./apps/cli/dist/deb/*.deb
+
+            - name: Upload debian packages to S3
+              working-directory: apps/cli
+              run: |
+                yarn oclif upload deb
+
+    pack_upload_tarballs:
+      runs-on: ubuntu-latest
+      if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
+      steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup environment
+              uses: './.github/actions/cli-ci-setup'
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
+                  aws-region: ${{ secrets.AWS_REGION }}
+
+            - name: Building tarballs
+              run: yarn oclif pack tarballs --root="./apps/cli"
+
+            - name: Upload tarball packages to Github artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: Packages-tarballs
+                  path: ./apps/cli/dist/*.tar.*
+
+            - name: Upload tarball packages to S3
+              working-directory: apps/cli
+              run: |
+                yarn oclif upload tarballs
+
+    promote-deb-and-tarballs:
+      needs: [pack_upload_deb, pack_upload_tarballs]
+      runs-on: ubuntu-latest
+      steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup environment
+              uses: './.github/actions/cli-ci-setup'
+
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
+                  aws-region: ${{ secrets.AWS_REGION }}
+
+            - name: Download deb packages from Github artifacts
+              uses: actions/download-artifact@v3
+              with:
+                name: Packages-deb
+                path: apps/cli/dist
+
+            - name: List all the downloaded files (for debugging)
+              run: ls -R
+              working-directory: apps/cli/dist
+
+            - name: Extract version and SHA
+              id: extract_info
+              run: |
+                filename=$(find . -name '*amd64.deb' -type f)
+                version=$(echo "$filename" | sed -n 's/.*_\([0-9]*\.[0-9]*\.[0-9]*\).*-.*\.deb/\1/p')
+                sha=$(echo "$filename" | sed -n 's/.*\.\([^-]*\)-.*\.deb/\1/p')
+
+                echo "::set-output name=version::$version"
+                echo "::set-output name=sha::$sha"
+              working-directory: apps/cli/dist
+
+            - name: Promote packages to S3
+              run: |
+                yarn oclif promote --deb --xz --indexes --version=${{ steps.extract_info.outputs.version }} --sha=${{ steps.extract_info.outputs.sha }}
+                aws s3 cp  s3://cli-prod-sunodo-origin/versions/${{ steps.extract_info.outputs.version }}/${{ steps.extract_info.outputs.sha }}/apt/./ s3://cli-prod-sunodo-origin/channels/stable/apt/./ --recursive
+              working-directory: apps/cli

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -83,6 +83,13 @@
             "@oclif/plugin-update"
         ],
         "topicSeparator": " ",
+        "update": {
+            "s3": {
+                "xz": true,
+                "bucket": "cli-prod-sunodo-origin",
+                "host": "https://cli.sunodo.io"
+            }
+        },
         "macos": {
             "identifier": "io.sunodo.cli"
         }

--- a/apps/cli/scripts/install-debian.sh
+++ b/apps/cli/scripts/install-debian.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+{
+    set -e
+    SUDO=''
+    if [ "$(id -u)" != "0" ]; then
+      SUDO='sudo'
+      echo "This script requires superuser access to install apt packages."
+      echo "You will be prompted for your password by sudo."
+      # clear any previous sudo permission
+      sudo -k
+    fi
+
+    # run inside sudo
+    $SUDO sh <<SCRIPT
+  set -ex
+
+  # if apt-transport-https is not installed, clear out old sources, update, then install apt-transport-https
+  dpkg -s apt-transport-https 1>/dev/null 2>/dev/null || \
+    (echo "" > /etc/apt/sources.list.d/sunodo.list \
+      && apt-get update \
+      && apt-get install -y apt-transport-https gnupg2 curl)
+
+  # add sunodo repository to apt
+  echo "deb https://cli.sunodo.io/channels/stable/apt ./" > /etc/apt/sources.list.d/sunodo.list
+
+  # install sunodo's release key for package verification
+  curl -sS https://cli.sunodo.io/release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/sunodo.gpg
+
+  # update your sources
+  apt-get update
+
+  # install the sunodo
+  apt-get install -y sunodo
+
+SCRIPT
+  # test the CLI
+  LOCATION=$(which sunodo)
+  echo "sunodo installed to $LOCATION"
+  sunodo help
+}

--- a/apps/cli/tf/.gitignore
+++ b/apps/cli/tf/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/apps/cli/tf/.terraform.lock.hcl
+++ b/apps/cli/tf/.terraform.lock.hcl
@@ -1,0 +1,97 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 2.0.0, >= 3.0.0, >= 3.64.0, >= 4.0.0, ~> 4.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "h1:LfOuBkdYCzQhtiRvVIxdP/KGJODa3cRsKjn8xKCTbVY=",
+    "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.4.0"
+  constraints = ">= 1.2.0"
+  hashes = [
+    "h1:7RnIbO3CFakblTJs7o0mUiY44dc9xGYsLhSNFSNS1Ds=",
+    "h1:Bs7LAkV/iQTLv72j+cTMrvx2U3KyXrcVHaGbdns1NcE=",
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
+    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
+    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
+    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
+    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
+    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
+    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
+    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
+    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
+    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
+    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:3hjTP5tQBspPcFAJlfafnWrNrKnr7J4Cp0qB9jbqf30=",
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.9.1"
+  constraints = ">= 0.7.0"
+  hashes = [
+    "h1:NUv/YtEytDQncBQ2mTxnUZEy/rmDlPYmE9h2iokR0vk=",
+    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
+    "h1:VxyoYYOCaJGDmLz4TruZQTSfQhvwEcMxvcKclWdnpbs=",
+    "h1:XYUT7lKAKuaHbCTp/WnjWBjz/C86JGvQUfS2s473Pjg=",
+    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
+    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
+    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
+    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
+    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
+    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
+    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
+    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
+    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
+    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}

--- a/apps/cli/tf/README.md
+++ b/apps/cli/tf/README.md
@@ -1,0 +1,61 @@
+# Terraform Configuration
+
+This directory contains Terraform code for managing infrastructure using Terraform Cloud. The configuration sets up resources in the AWS cloud provider account.
+
+## Requirements
+
+Before using this Terraform configuration, ensure you have the following:
+
+- **Terraform Cloud Account**: Sign up for a [Terraform Cloud account](https://app.terraform.io/signup) if you don't have one already. Terraform Cloud will be used to manage the execution and state of your Terraform runs.
+
+- **AWS Account**: You should have access to an [AWS account](https://aws.amazon.com/free) where you want to provision and manage your infrastructure.
+
+- **Terraform Variables**: The Terraform configuration requires certain variables to be set. Please refer to the [variables.tf](./variables.tf) file for the list of variables and their descriptions. You can set these variables in Terraform Cloud with `TF_VAR_` prefix or provide them as environment variables when running Terraform locally.
+
+## Getting Started
+
+To get started with this Terraform configuration, follow these steps:
+
+1. **Clone the repository**:
+
+   ```shell
+   git clone https://github.com/sunodo/sunodo.git
+
+2. **Navigate to the Terraform configuration directory**:
+
+   ```shell
+   cd apps/cli/tf/
+
+3. **Set up a Terraform Cloud workspace**:
+
+- Log in to Terraform Cloud.
+- Create a new workspace.
+- Link the workspace to your cloned GitHub repository. Refer to the [Terraform Cloud Documentation](https://www.terraform.io/docs/cloud/workspaces/vcs.html) for detailed instructions.
+
+4. **Configure Terraform variables**:
+
+- Set the required Terraform variables either in your Terraform Cloud workspace or as environment variables. Refer to the `variables.tf` file for the list of variables and their descriptions.
+
+5. **Run Terraform**:
+
+- If using Terraform Cloud:
+
+  - Push changes to your GitHub repository.
+  - Terraform Cloud will automatically detect the changes and trigger a Terraform run in your configured workspace.
+
+- If running locally:
+
+  - Install Terraform CLI.
+  - Change to the project directory.
+  - Initialize Terraform using `terraform init`.
+  - Configure the necessary input variables either through environment variables or using a `terraform.tfvars` file.
+  - Apply the Terraform configuration using `terraform apply`.
+
+## Contributing
+
+We welcome contributions to enhance and improve this Terraform configuration. To contribute:
+
+- Fork the repository.
+- Create a new branch for your changes.
+- Make the necessary modifications.
+- Submit a pull request.

--- a/apps/cli/tf/bucket.tf
+++ b/apps/cli/tf/bucket.tf
@@ -1,0 +1,82 @@
+module "acm_request_certificate" {
+  source = "cloudposse/acm-request-certificate/aws"
+
+  # https://github.com/cloudposse/terraform-aws-acm-request-certificate
+  version                           = "v0.17.0"
+  domain_name                       = "cli.sunodo.io"
+  process_domain_validation_options = true
+  ttl                               = "300"
+  zone_id                           = var.sunodo_prod_route53_zone_id
+}
+
+module "cdn" {
+  source = "cloudposse/cloudfront-s3-cdn/aws"
+
+  # https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/tree/0.90.0
+  version                             = "v0.90.0"
+  name                                = "sunodo"
+  namespace                           = "cli"
+  stage                               = "prod"
+  aliases                             = ["cli.sunodo.io"]
+  dns_alias_enabled                   = true
+  parent_zone_id                      = var.sunodo_prod_route53_zone_id
+  acm_certificate_arn                 = module.acm_request_certificate.arn
+  cloudfront_access_log_create_bucket = false
+  cloudfront_access_logging_enabled   = false
+  allowed_methods                     = ["GET", "HEAD", "OPTIONS"]
+  cached_methods                      = ["GET", "HEAD"]
+  versioning_enabled                  = false
+  block_origin_public_access_enabled  = false
+
+  depends_on = [module.acm_request_certificate]
+}
+
+data "aws_iam_policy_document" "sunodo_cli_s3_doc" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::cli-prod-sunodo-origin",
+    ]
+  }
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutBucketPolicy",
+      "s3:GetBucketPolicy",
+      "s3:PutBucketAcl",
+      "s3:GetBucketAcl",
+      "s3:PutObjectAcl",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+      "s3:GetObjectAcl",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "arn:aws:s3:::cli-prod-sunodo-origin/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "sunodo_cli_s3_policy" {
+  name        = "sunodo_cli_s3_policy"
+  path        = "/"
+  description = "Sunodo CLI S3 Storage Policy"
+  policy      = data.aws_iam_policy_document.sunodo_cli_s3_doc.json
+}
+
+module "iam_iam-assumable-role-with-oidc" {
+  # https://github.com/terraform-aws-modules/terraform-aws-iam/tree/v5.20.0/modules/iam-assumable-role-with-oidc
+  source                         = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                        = "5.20.0"
+  create_role                    = true
+  role_name                      = "sunodo_cli"
+  provider_url                   = "token.actions.githubusercontent.com"
+  oidc_fully_qualified_audiences = ["sts.amazonaws.com"]
+  oidc_subjects_with_wildcards   = ["repo:sunodo/sunodo:*"]
+  role_policy_arns               = [aws_iam_policy.sunodo_cli_s3_policy.arn]
+}

--- a/apps/cli/tf/main.tf
+++ b/apps/cli/tf/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "aws" {
+  region = var.sunodo_prod_region
+  default_tags {
+    tags = {
+      Owner     = "sunodo-team"
+      ManagedBy = "Terraform"
+    }
+  }
+}

--- a/apps/cli/tf/outputs.tf
+++ b/apps/cli/tf/outputs.tf
@@ -1,0 +1,4 @@
+output "GITHUB_IAM_ROLE_ARN" {
+  value       = module.iam_iam-assumable-role-with-oidc.iam_role_arn
+  description = "Connect to the S3 bucket from github with this arn"
+}

--- a/apps/cli/tf/variables.tf
+++ b/apps/cli/tf/variables.tf
@@ -1,0 +1,11 @@
+variable "sunodo_prod_region" {
+  description = "The sunodo prod AWS region"
+  type        = string
+  sensitive   = true
+}
+
+variable "sunodo_prod_route53_zone_id" {
+  description = "The sunodo prod route53 zone ID"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Here's a step-by-step breakdown of the provided Terraform code:

**Step 1:** S3 Bucket Configuration

- Creates an S3 bucket named `cli-prod-sunodo-origin` with the specified name and tags.
- Sets the bucket ACL to "private" using `aws_s3_bucket_acl` resource.
- Configures bucket ownership controls to allow ObjectWriter access using `aws_s3_bucket_ownership_controls` resource.
- Sets up public access block configuration to disallow public access to the bucket using `aws_s3_bucket_public_access_block` resource.

**Step 2:** IAM Configuration

- Defines an IAM policy document using `data.aws_iam_policy_document` to specify the required actions and resources.
- Creates an IAM policy named `sunodo_cli` with the defined policy document using `aws_iam_policy` resource.
- Creates an IAM identity_providers for github OIDC

**Step 3:** CloudFront Configuration

- Creates a CloudFront origin access identity named `sunodo_cli_origin_access_identity` using `aws_cloudfront_origin_access_identity` resource.
- Defines an IAM role named `cloudfront-iam-role` with an assume role policy allowing CloudFront service to assume the role using `aws_iam_role` resource.
- Defines an IAM policy named `cloudfront-iam-policy` with the required permissions using `aws_iam_policy` resource.
- Attaches the IAM policy to the IAM role using `aws_iam_role_policy_attachment` resource.
- Creates an ACM certificate for the domain `cli.sunodo.io` and `*.sunodo.io` using `aws_acm_certificate` resource. (**wildcard**)
- Creates a CloudFront distribution named `sunodo_cli`_distribution with the specified settings, including the S3 bucket origin, viewer certificate, cache behavior, and restrictions using `aws_cloudfront_distribution` resource.
- Associates the CloudFront distribution with the subdomain `cli.sunodo.io` using a **CNAME** record in Route 53 using `aws_route53_record` resource.
