### PR TITLE
Contracts deployment using anvil_loadState

### DIFF
--- a/.changeset/popular-needles-beam.md
+++ b/.changeset/popular-needles-beam.md
@@ -1,0 +1,7 @@
+---
+"anvil": major
+---
+
+-   Changing Docker image from ENTRYPOINT to CMD (breaking change)
+-   Adding `eth_dump` and `eth_load` tools
+-   Change CI to use monorepo tags like `anvil@<version>`

--- a/.github/workflows/anvil.yaml
+++ b/.github/workflows/anvil.yaml
@@ -4,7 +4,7 @@ on:
         branches:
             - main
         tags:
-            - v*
+            - anvil@*
     pull_request:
         paths:
             - .github/workflows/anvil.yaml
@@ -30,8 +30,7 @@ jobs:
                       docker.io/sunodo/anvil,enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/sunodo/anvil
                   tags: |
-                      type=semver,pattern={{version}}
-                      type=edge
+                      type=match,pattern=(.+)@(.*),group=2
                       type=ref,event=pr
                   labels: |
                       org.opencontainers.image.title=Sunodo anvil

--- a/packages/anvil/Dockerfile
+++ b/packages/anvil/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:bullseye-20230502-slim
 # install curl and jq (for healthcheck support)
 RUN <<EOF
 apt-get update
-DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends ca-certificates curl jq
+DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends ca-certificates curl jq xxd
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -14,7 +14,9 @@ RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly/fo
 
 # healthcheck script using net_listening JSON-RPC method
 COPY eth_isready /usr/local/bin
+COPY eth_dump /usr/local/bin
+COPY eth_load /usr/local/bin
 
 HEALTHCHECK CMD eth_isready
 
-ENTRYPOINT ["/usr/local/bin/anvil"]
+CMD ["anvil"]

--- a/packages/anvil/README.md
+++ b/packages/anvil/README.md
@@ -1,0 +1,47 @@
+# Anvil
+
+## Usage
+
+```shell
+docker run sunodo/anvil
+```
+
+## Building
+
+```shell
+docker buildx bake --load
+```
+
+## Export anvil state
+
+Run anvil and deploy any contracts.
+Then run:
+
+```shell
+./eth_dump
+```
+
+The environment variable `RPC_URL` can be defined to control the address of `anvil`, and defaults to `http://127.0.0.1:8545`.
+You need the following tools installed:
+
+-   curl
+-   jq
+-   cut
+-   xxd
+
+If you are running `anvil` as a Docker container you can use the following command to export the state to a `.gz` file.
+
+```shell
+docker exec <container> eth_dump | gzip > <file.gz>
+```
+
+## Load anvil state
+
+Run `anvil` and load the state produced by `eth_dump` above with:
+
+```shell
+./eth_load
+```
+
+It loads the state reading from `stdin`.
+The environment variable `RPC_URL` can be defined to control the address of anvil, and defaults to `http://127.0.0.1:8545`.

--- a/packages/anvil/docker-bake.hcl
+++ b/packages/anvil/docker-bake.hcl
@@ -3,5 +3,4 @@ target "docker-platforms" {}
 
 target "default" {
   inherits = ["docker-metadata-action", "docker-platforms"]
-  tags     = ["sunodo/anvil:devel"]
 }

--- a/packages/anvil/eth_dump
+++ b/packages/anvil/eth_dump
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# dump the state from the JSON-RPC server, convert from the hex anvil returns to text, which is a JSON string
+curl \
+    -sL \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    --data '{"id":1,"jsonrpc":"2.0","method":"anvil_dumpState","params":[]}' "${RPC_URL:-http://127.0.0.1:8545}" | \
+jq -r .result| \
+cut -c 3- | \
+xxd -r -p

--- a/packages/anvil/eth_load
+++ b/packages/anvil/eth_load
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -e
+RPC_URL="${RPC_URL:-http://127.0.0.1:8545}"
+
+# use a large column value so we have everything on one line, even though man says 256 is the maximum
+STATE=$(xxd -ps -c 1000000000)
+
+# build the JSON-RPC request, and write to a file because it's too long for the curl call
+DATA="{\"id\":2,\"jsonrpc\":\"2.0\",\"method\":\"anvil_loadState\",\"params\":[\"0x$STATE\"]}"
+TMPFILE=$(mktemp)
+echo "$DATA" > "$TMPFILE"
+
+echo "Loading state into ${RPC}"
+curl -sL -H 'Content-Type: application/json' -d @"$TMPFILE" "$RPC_URL" | jq -r .result

--- a/packages/anvil/package.json
+++ b/packages/anvil/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "anvil",
+    "private": true,
+    "version": "1.0.0"
+}

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,19 +1,20 @@
 {
-  "name": "eslint-config-custom",
-  "version": "0.0.0",
-  "main": "index.js",
-  "license": "MIT",
-  "dependencies": {
-    "eslint": "8.36.0",
-    "eslint-config-next": "13.2.4",
-    "eslint-config-prettier": "8.8.0",
-    "eslint-config-turbo": "0.0.10",
-    "eslint-plugin-react": "latest"
-  },
-  "devDependencies": {
-    "typescript": "^5.0.2"
-  },
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "eslint-config-custom",
+    "version": "0.0.0",
+    "main": "index.js",
+    "license": "MIT",
+    "private": true,
+    "dependencies": {
+        "eslint": "8.36.0",
+        "eslint-config-next": "13.2.4",
+        "eslint-config-prettier": "8.8.0",
+        "eslint-config-turbo": "0.0.10",
+        "eslint-plugin-react": "latest"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.2"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,19 +1,20 @@
 {
-  "name": "ui",
-  "version": "0.0.0",
-  "main": "./index.tsx",
-  "types": "./index.tsx",
-  "license": "MIT",
-  "scripts": {
-    "lint": "TIMING=1 eslint \"**/*.ts*\""
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
-    "eslint": "^8.36.0",
-    "eslint-config-custom": "*",
-    "react": "^18.2.0",
-    "tsconfig": "*",
-    "typescript": "^5.0.2"
-  }
+    "name": "ui",
+    "version": "0.0.0",
+    "main": "./index.tsx",
+    "types": "./index.tsx",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+        "lint": "TIMING=1 eslint \"**/*.ts*\""
+    },
+    "devDependencies": {
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.11",
+        "eslint": "^8.36.0",
+        "eslint-config-custom": "*",
+        "react": "^18.2.0",
+        "tsconfig": "*",
+        "typescript": "^5.0.2"
+    }
 }


### PR DESCRIPTION
This provides tools for dumping and loading anvil state.

Instead of deploying contracts using `cartesi/rollups-hardhat:0.9.0` during node startup, which is a `hardhat` project deployment, we could do that during build time, dump the state of anvil to a file, and distribute the file as part of sunodo CLI.

The during node startup we can just load the state from the file to anvil.

The files generated by `hardhat`, `localhost.json` and the `deployments/localhost` directory could be also packaged during build time.
