### PR TITLE
Setting up gpg key for signing

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -19,9 +19,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env:
-          SUNODO_DEB_KEY: ${{ secrets.SUNODO_DEB_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -43,17 +42,27 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
               run: yarn global add oclif
 
+            - name: Install GPG key for debian package signing
+              id: gpg_key
+              if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
+              uses: crazy-max/ghaction-import-gpg@v5
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
             - name: Build debian package
               if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
               run: oclif pack deb
               working-directory: apps/cli
+              env:
+                  SUNODO_DEB_KEY: ${{ steps.gpg_key.outputs.keyid }}
 
             - name: Upload debian packages to Github artifacts
               if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')
               uses: actions/upload-artifact@v3
               with:
-                name: Packages
-                path: ./apps/cli/dist/deb/*.deb
+                  name: Packages
+                  path: ./apps/cli/dist/deb/*.deb
 
             - name: Publish debian packages to S3
               if: startsWith(github.ref, 'refs/tags/@sunodo/cli@')


### PR DESCRIPTION
This uses the [import GPG key action](https://github.com/marketplace/actions/import-gpg) to import the key from GitHub secret to the keyring.

Then it uses the imported key ID in the debian package generation step.
