### PR TITLE
Fix main versions procedure

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -92,7 +92,7 @@
     "engines": {
         "node": ">=18.0.0"
     },
-    "bugs": "https://github.com/cartesi/sunodo/issues",
+    "bugs": "https://github.com/sunodo/sunodo/issues",
     "keywords": [
         "oclif"
     ],

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,8 @@
         "dev": {
             "cache": false
         },
-        "version": {}
+        "version": {
+            "dependsOn": ["^build"]
+        }
     }
 }


### PR DESCRIPTION
This adds the `build` command as a dependency of the `version` command, so it runs and before it.
