### PR TITLE
ci: get docker tags from package.json

### DIFF
--- a/.github/workflows/anvil.yaml
+++ b/.github/workflows/anvil.yaml
@@ -1,8 +1,6 @@
 name: anvil
 on:
-    push:
-        tags:
-            - anvil@*
+    workflow_call:
     pull_request:
         paths:
             - .github/workflows/anvil.yaml
@@ -13,12 +11,19 @@ concurrency:
 permissions:
     contents: read
     packages: write
+    actions: write
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v3
+
+            - name: Get package tag/version
+              id: package-version
+              if: ${{ github.event_name == 'push' }}
+              run: |
+                  jq -r '"PACKAGE_VERSION=\(.version)"' packages/anvil/package.json >> "$GITHUB_OUTPUT"
 
             - name: Docker meta
               id: meta
@@ -28,7 +33,7 @@ jobs:
                       docker.io/sunodo/anvil,enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/sunodo/anvil
                   tags: |
-                      type=match,pattern=(.+)@(.*),group=2
+                      type=raw,value=${{ steps.package-version.outputs.PACKAGE_VERSION }},enable=${{ github.event_name == 'push' }}
                       type=ref,event=pr
                   labels: |
                       org.opencontainers.image.title=Sunodo anvil

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -1,8 +1,6 @@
 name: contracts
 on:
-    push:
-        tags:
-            - "@sunodo/contracts@*"
+    workflow_call:
     pull_request:
         paths:
             - .github/workflows/contracts.yaml
@@ -13,6 +11,7 @@ concurrency:
 permissions:
     contents: write
     packages: write
+    actions: write
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -39,6 +38,12 @@ jobs:
             - name: Build
               run: yarn build --filter=contracts
 
+            - name: Get package tag/version
+              id: package-version
+              if: ${{ github.event_name == 'push' }}
+              run: |
+                  jq -r '"PACKAGE_VERSION=\(.version)"' packages/contracts/package.json >> "$GITHUB_OUTPUT"
+
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v4
@@ -47,7 +52,7 @@ jobs:
                       docker.io/sunodo/deployments,enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/sunodo/deployments
                   tags: |
-                      type=match,pattern=(.+)@(.*),group=2
+                      type=raw,value=${{ steps.package-version.outputs.PACKAGE_VERSION }},enable=${{ github.event_name == 'push' }}
                       type=ref,event=pr
                   labels: |
                       org.opencontainers.image.title=Sunodo's deployments

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ jobs:
     release:
         name: Release
         runs-on: ubuntu-latest
+        outputs:
+            published: ${{ steps.changeset.outputs.published }}
+            publishedPackages: ${{ steps.changeset.outputs.publishedPackages }}
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v3
@@ -35,3 +38,40 @@ jobs:
                   publish: yarn run publish-packages
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    packages_to_build:
+        name: Get released packages
+        runs-on: ubuntu-latest
+        needs: release
+        if: ${{ needs.release.outputs.published == 'true' }}
+        outputs:
+            packages: ${{ steps.packages.outputs.PACKAGES }}
+        steps:
+            - name: Get released packages
+              id: packages
+              run: |
+                  echo "PACKAGES=$(jq -c '[ .[].name ]' <(echo '${{ needs.release.outputs.publishedPackages }}'))" >> "$GITHUB_OUTPUT"
+
+    build_rollups_node:
+        name: Build rollups-node
+        needs: [release, packages_to_build]
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'rollups-node') }}
+        uses: ./.github/workflows/rollups-node.yaml
+
+    build_sdk:
+        name: Build sdk
+        needs: [release, packages_to_build]
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'sdk') }}
+        uses: ./.github/workflows/sdk.yaml
+
+    build_anvil:
+        name: Build anvil
+        needs: [release, packages_to_build]
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'anvil') }}
+        uses: ./.github/workflows/anvil.yaml
+
+    build_contracts:
+        name: Build contracts
+        needs: [release, packages_to_build]
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'contracts') }}
+        uses: ./.github/workflows/contracts.yaml

--- a/.github/workflows/rollups-node.yaml
+++ b/.github/workflows/rollups-node.yaml
@@ -1,8 +1,6 @@
 name: rollups-node
 on:
-    push:
-        tags:
-            - rollups-node@*
+    workflow_call:
     pull_request:
         paths:
             - .github/workflows/rollups-node.yaml
@@ -13,12 +11,19 @@ concurrency:
 permissions:
     contents: read
     packages: write
+    actions: write
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v3
+
+            - name: Get package tag/version
+              id: package-version
+              if: ${{ github.event_name == 'push' }}
+              run: |
+                  jq -r '"PACKAGE_VERSION=\(.version)"' packages/rollups-node/package.json >> "$GITHUB_OUTPUT"
 
             - name: Docker meta
               id: meta
@@ -28,7 +33,7 @@ jobs:
                       docker.io/sunodo/rollups-node,enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/sunodo/rollups-node
                   tags: |
-                      type=match,pattern=(.+)@(.*),group=2
+                      type=raw,value=${{ steps.package-version.outputs.PACKAGE_VERSION }},enable=${{ github.event_name == 'push' }}
                       type=ref,event=pr
                   labels: |
                       org.opencontainers.image.title=Sunodo's rollups-node

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -1,8 +1,6 @@
 name: sdk
 on:
-    push:
-        tags:
-            - sdk@*
+    workflow_call:
     pull_request:
         paths:
             - .github/workflows/sdk.yaml
@@ -14,12 +12,19 @@ permissions:
     contents: read
     packages: write
     id-token: write
+    actions: write
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v3
+
+            - name: Get package tag/version
+              id: package-version
+              if: ${{ github.event_name == 'push' }}
+              run: |
+                  jq -r '"PACKAGE_VERSION=\(.version)"' packages/sdk/package.json >> "$GITHUB_OUTPUT"
 
             - name: Docker meta
               id: meta
@@ -29,7 +34,7 @@ jobs:
                       docker.io/sunodo/sdk,enable=${{ github.event_name != 'pull_request' }}
                       ghcr.io/sunodo/sdk
                   tags: |
-                      type=match,pattern=(.+)@(.*),group=2
+                      type=raw,value=${{ steps.package-version.outputs.PACKAGE_VERSION }},enable=${{ github.event_name == 'push' }}
                       type=ref,event=pr
                   labels: |
                       org.opencontainers.image.title=Sunodo SDK


### PR DESCRIPTION
With this PR, al docker packaged will still be built with the `:pr-NN` suffix.

Whenever a chageset release is made at the release workflow, and this released contains a docker package to build, the corresponding workflow will be called, instead of depending on the `on.push.tags` trigger.

/close #105 