### PR TITLE
Deploy provider URL

### DIFF
--- a/apps/cli/src/wallet.ts
+++ b/apps/cli/src/wallet.ts
@@ -126,14 +126,11 @@ const selectTransport = async (
     if (options.rpcUrl) {
         return http(options.rpcUrl);
     } else {
-        if (chain.rpcUrls.public.http) {
-            // or chain.rpcUrls.default.http ?
-            // if no url is provided, then the transport will fall back to a public RPC URL on the chain
-            return http();
-        } else {
-            const url = await input({ message: "RPC URL" });
-            return http(url);
-        }
+        const url = await input({
+            message: "RPC URL",
+            default: chain.rpcUrls.public.http[0],
+        });
+        return http(url);
     }
 };
 


### PR DESCRIPTION
This changes the interactive mode to always ask for the chain provider URL, with a default value coming from the `@wagmi/chains` package public URL.

This makes it more clear what the URL is, even for local deploy with `--dev`.
