### PR TITLE
Specify payee to PayableDAppFactory

### DIFF
--- a/.changeset/rich-berries-decide.md
+++ b/.changeset/rich-berries-decide.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/contracts": minor
+---
+
+using a payee for the PayableDAppFactory instead of using the contract as token holder

--- a/packages/contracts/contracts/deploy/IPayableDAppFactory.sol
+++ b/packages/contracts/contracts/deploy/IPayableDAppFactory.sol
@@ -52,6 +52,9 @@ interface IPayableDAppFactory {
     /// @notice The consensus wired to the factory
     function consensus() external view returns (IConsensus);
 
+    /// @notice The address which will receive payments for the applications
+    function payee() external view returns (address);
+
     /// @notice Returns the runway of a given DApp
     /// @param _dapp The DApp address
     function runway(ICartesiDApp _dapp) external view returns (uint256);

--- a/packages/contracts/contracts/deploy/IPayableDAppSystem.sol
+++ b/packages/contracts/contracts/deploy/IPayableDAppSystem.sol
@@ -13,19 +13,26 @@ interface IPayableDAppSystem {
     /// @notice A new factory was created
     /// @param factory The address of the factory
     /// @param token The token used for billing
+    /// @param payee The address that will receive the payments
     /// @param consensus The consensus associated with the factory
     /// @param price The price per minute of dapp node execution
     event PayableDAppFactoryCreated(
         IPayableDAppFactory factory,
         IERC20 token,
+        address payee,
         IConsensus consensus,
         uint256 price
     );
 
     /// @notice Create a new ERC20 based DApp factory using the specified token
+    /// @param token The token used for billing
+    /// @param payee The address that will receive the payments
+    /// @param consensus The consensus associated with the factory
+    /// @param price The price per second of application node execution
     function newPayableDAppFactory(
-        IERC20 _token,
+        IERC20 token,
+        address payee,
         IConsensus consensus,
-        uint256 _price
+        uint256 price
     ) external returns (IPayableDAppFactory);
 }

--- a/packages/contracts/contracts/deploy/PayableDAppSystem.sol
+++ b/packages/contracts/contracts/deploy/PayableDAppSystem.sol
@@ -24,6 +24,7 @@ contract PayableDAppSystem is IPayableDAppSystem {
     /// @notice Create a new ERC20 based DApp factory using the specified token
     function newPayableDAppFactory(
         IERC20 _token,
+        address _payee,
         IConsensus _consensus,
         uint256 _price
     ) external returns (IPayableDAppFactory) {
@@ -31,6 +32,7 @@ contract PayableDAppSystem is IPayableDAppSystem {
         PayableDAppFactory payableFactory = new PayableDAppFactory(
             msg.sender,
             ens,
+            _payee,
             factory,
             _token,
             _consensus,
@@ -41,6 +43,7 @@ contract PayableDAppSystem is IPayableDAppSystem {
         emit PayableDAppFactoryCreated(
             payableFactory,
             _token,
+            _payee,
             _consensus,
             _price
         );


### PR DESCRIPTION
This specifies the payee of a `PayableDAppFactory`, instead of depositing the money in the contract itself.
The transfer is now from the deployer to the payee.
The withdraw method was removed.

I believe this will pave the way better for the possible revenue share mode using Payment Splitter.
