### PR TITLE
Hide deploy commands and docs

### DIFF
--- a/apps/cli/src/commands/controller.ts
+++ b/apps/cli/src/commands/controller.ts
@@ -36,6 +36,8 @@ export default class Controller extends Command {
 
     static examples = ["<%= config.bin %> <%= command.id %>"];
 
+    static hidden = true;
+
     static flags = {
         "rpc-url": Flags.string({
             description: "JSON-RPC url of ethereum node",

--- a/apps/cli/src/commands/deploy/index.ts
+++ b/apps/cli/src/commands/deploy/index.ts
@@ -69,6 +69,8 @@ export default class Deploy extends DeployBaseCommand<typeof Deploy> {
 
     static examples = ["<%= config.bin %> <%= command.id %>"];
 
+    static hidden = true;
+
     static networkFlags = {
         "chain-id": Flags.integer({
             summary: "network to deploy to",

--- a/apps/cli/src/commands/deploy/list.ts
+++ b/apps/cli/src/commands/deploy/list.ts
@@ -8,6 +8,8 @@ import { supportedChains } from "../../wallet.js";
 export default class DeployList extends DeployBaseCommand<typeof DeployList> {
     static summary = "List deployments of the application.";
 
+    static hidden = true;
+
     static enableJsonFlag = true;
 
     static description =

--- a/apps/docs/guide/deploying/billing.md
+++ b/apps/docs/guide/deploying/billing.md
@@ -1,5 +1,9 @@
 # Billing system
 
+::: warning
+This is still under development and will be available in a future release.
+:::
+
 The deployment of an application is done through a `PayableDAppFactory` smart contract.
 
 The contract defines which ERC-20 token is accepted as payment and the price of application execution per unit of time (second). In the current design, the price is fixed, and cannot be changed by the validator.

--- a/apps/docs/guide/deploying/deploying-application.md
+++ b/apps/docs/guide/deploying/deploying-application.md
@@ -1,5 +1,9 @@
 # Deploying application
 
+::: warning
+This is still under development and will be available in a future release.
+:::
+
 The deployment of an application is done in two basic steps:
 
 1. Upload of the application Cartesi machine to IPFS;

--- a/apps/docs/guide/deploying/supported-networks.md
+++ b/apps/docs/guide/deploying/supported-networks.md
@@ -1,5 +1,9 @@
 # Supported networks
 
+::: warning
+This is still under development and will be available in a future release.
+:::
+
 Sunodo deployment supports all networks officially supported by the Cartesi rollups framework:
 
 -   Ethereum

--- a/apps/docs/guide/deploying/validator.md
+++ b/apps/docs/guide/deploying/validator.md
@@ -1,5 +1,9 @@
 # Becoming a Validator
 
+::: warning
+This is still under development and will be available in a future release.
+:::
+
 The following diagram illustrates the deployment system implemented by Sunodo.
 
 ![Deployment overview](./deploy-overview.jpg)

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -1,22 +1,22 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
-  "extends": "./base.json",
-  "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "incremental": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
-  },
-  "include": ["src", "next-env.d.ts"],
-  "exclude": ["node_modules"]
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "Next.js",
+    "extends": "./base.json",
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "incremental": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve"
+    },
+    "include": ["src", "next-env.d.ts"],
+    "exclude": ["node_modules"]
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "tsconfig",
-  "version": "0.0.0",
-  "private": true,
-  "files": [
-    "base.json",
-    "nextjs.json",
-    "react-library.json"
-  ]
+    "name": "tsconfig",
+    "version": "0.0.0",
+    "private": true,
+    "files": [
+        "base.json",
+        "nextjs.json",
+        "react-library.json"
+    ]
 }

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
-  "extends": "./base.json",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "lib": ["ES2015"],
-    "module": "ESNext",
-    "target": "es6"
-  }
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "React Library",
+    "extends": "./base.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "lib": ["ES2015"],
+        "module": "ESNext",
+        "target": "es6"
+    }
 }


### PR DESCRIPTION
This PR hides the deploy and controller commands while they are not ready.
This will allow to release a new version without the deployment system, but which works with rollups 1.0.0.
