### PR TITLE
Fetch entire git repo, including tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
             - name: Checkout Repo
               uses: actions/checkout@v3
               with:
-                  fetch-tags: true
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v3


### PR DESCRIPTION
Fact: we need to fetch tags on the release workflow.

The code below only fetches tags which belong to the fetched history, which in this case is only 1 commit, as the default `fetch-depth` is 1.

```
uses: actions/checkout@v3
with:
    fetch-tags: true
```

So we will need to checkout the entire history by using `fetch-depth` zero, which includes all tags.
```
uses: actions/checkout@v3
with:
    fetch-depth: 0
```
