### PR TITLE
Fix address-book so getting dapp address works with no-backend

### DIFF
--- a/.changeset/young-kids-relate.md
+++ b/.changeset/young-kids-relate.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+fix address-book so getting dapp address works with no-backend

--- a/apps/cli/src/commands/send/index.ts
+++ b/apps/cli/src/commands/send/index.ts
@@ -70,14 +70,15 @@ export abstract class SendBaseCommand<
             return this.flags.dapp;
         }
 
-        // get the address book
-        const addressBook = await super.getAddressBook();
-        const dapp =
-            addressBook["CartesiDApp"] ||
-            (await input({
-                message: "DApp address",
-                validate: (value) => isAddress(value) || "Invalid address",
-            }));
+        // get the running container dapp address
+        const nodeAddress = await super.getDAppAddress();
+
+        // query for the address
+        const dapp = await input({
+            message: "DApp address",
+            validate: (value) => isAddress(value) || "Invalid address",
+            default: nodeAddress,
+        });
 
         return dapp as Address;
     }


### PR DESCRIPTION
1) simplification of rollups contracts of address-book, using values from the `contracts.ts` file that are already imported into the project by a build procedure.

2) the dapp address is read directly from a running anvil container, either of a normal node, or a no-backend node. I use cat to read it, instead of saving a host file with the address.

3) the send command now always asks for the address, and the one from (2) is presented as default value only.

`sunodo address-book` should print even without any node running, in that case without CartesiDApp address
`sunodo address-book` should also print dapp address if there is a running node, backend or no-backend

closes #154 