### PR TITLE
feat(cli): support .sunodo.env for sunodo run

### DIFF
--- a/.changeset/weak-badgers-wash.md
+++ b/.changeset/weak-badgers-wash.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+sunodo run will accept a .sunodo.env file

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -77,43 +77,31 @@ export default class Run extends Command {
             WS_URL: "ws://anvil:8545",
         };
 
-        // Construct the path for Docker Compose files
-        const composeFileDev = path.join(
+        const composeFiles = [];
+        const composeBasePath = path.join(
             "--file=",
             path.dirname(new URL(import.meta.url).pathname),
             "..",
-            "node",
-            "docker-compose-dev.yml",
-        );
-        const composeFileHost = path.join(
-            "--file=",
-            path.dirname(new URL(import.meta.url).pathname),
-            "..",
-            "node",
-            "docker-compose-host.yml",
-        );
+            "node"
+        )
 
-        // Use composeFileDev by default, add composeFileHost if --no-backend is defined
-        const selectedComposeFiles = flags["no-backend"]
-            ? [composeFileDev, composeFileHost]
-            : [composeFileDev];
+        const composeFileDev = path.join(composeBasePath, "docker-compose-dev.yml");
+        const composeFileHost = path.join(composeBasePath, "docker-compose-host.yml");
+        const composeFileEnvFile = path.join(composeBasePath, "docker-compose-envfile.yml");
 
-        // use .sunodo.env if it exists
-        if (fs.existsSync(".sunodo.env")) {
-            const composeEnv = path.join(
-                "--file=",
-                path.dirname(new URL(import.meta.url).pathname),
-                "..",
-                "node",
-                "docker-compose-envfile.yml",
-            )
+        composeFiles.push(composeFileDev);
 
-            selectedComposeFiles.push(composeEnv);
+        if (flags["no-backend"]) {
+            composeFiles.push(composeFileHost);
+        }
+
+        if (fs.existsSync("./.sunodo.env")) {
+            composeFiles.push(composeFileEnvFile);
         }
 
         const args = [
             "compose",
-            ...selectedComposeFiles,
+            ...composeFiles,
             "--project-directory",
             ".",
             "--project-name",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -98,6 +98,19 @@ export default class Run extends Command {
             ? [composeFileDev, composeFileHost]
             : [composeFileDev];
 
+        // use .sunodo.env if it exists
+        if (fs.existsSync(".sunodo.env")) {
+            const composeEnv = path.join(
+                "--file=",
+                path.dirname(new URL(import.meta.url).pathname),
+                "..",
+                "node",
+                "docker-compose-envfile.yml",
+            )
+
+            selectedComposeFiles.push(composeEnv);
+        }
+
         const args = [
             "compose",
             ...selectedComposeFiles,

--- a/apps/cli/src/node/docker-compose-envfile.yml
+++ b/apps/cli/src/node/docker-compose-envfile.yml
@@ -1,0 +1,5 @@
+version: "3.9"
+services:
+    validator:
+        env_file:
+            - ./.sunodo.env

--- a/apps/docs/guide/running/running-application.md
+++ b/apps/docs/guide/running/running-application.md
@@ -16,6 +16,21 @@ The private chain by default has a block time of 5 seconds, controlled by `--blo
 
 By default the node closes an epoch once a day, but this can be controlled by the `--epoch-duration <seconds>` command option. It's an important settings when it comes down to voucher execution.
 
+## Rollups Node configuration
+
+You can create a `.sunodo.env` file in the root of your project to configure the node.
+
+All Rollups Node services can be configured using environment variables.
+
+For ex., in case you want to change the default deadline for advancing the state for the rollups-advance-runner service.
+
+```shell
+cat .sunodo.env
+SM_DEADLINE_ADVANCE_STATE=360000
+```
+
+Check the configuration options for each service in the [Rollups Node documentation](https://github.com/cartesi/rollups/blob/v1.0.1/offchain/README.md).
+
 ## No-backend mode
 
 Sunodo `run` also supports running a node without the user application backend packaged as a Cartesi machine. In this case the user application can be executed on the host, without the concern of being compiled to RISC-V.


### PR DESCRIPTION
This PR will make `sunodo run` accept a `.sunodo.env` file which make the sunodo/rollups-node container load the environment variables, so that one can pass variables to the sunodo/rollups-node services.
