### PR TITLE
Fix/ci avoid deadlock

### DIFF
--- a/.github/workflows/anvil.yaml
+++ b/.github/workflows/anvil.yaml
@@ -6,7 +6,7 @@ on:
             - .github/workflows/anvil.yaml
             - packages/anvil/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: read

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -11,7 +11,7 @@ on:
             - packages/eslint-config-custom/**
             - packages/tsconfig/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: read

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -6,7 +6,7 @@ on:
             - .github/workflows/contracts.yaml
             - packages/contracts/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: write

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -6,7 +6,7 @@ on:
             - .github/workflows/devnet.yaml
             - packages/devnet/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: read

--- a/.github/workflows/rollups-node.yaml
+++ b/.github/workflows/rollups-node.yaml
@@ -6,7 +6,7 @@ on:
             - .github/workflows/rollups-node.yaml
             - packages/rollups-node/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: read

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -6,7 +6,7 @@ on:
             - .github/workflows/sdk.yaml
             - packages/sdk/**
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
     cancel-in-progress: true
 permissions:
     contents: read


### PR DESCRIPTION
This PR should solve the deadlock problem for reusable workflows that are called from the release workflow during push do main.