### PR TITLE
Bump minimum docker compose version to 2.21.0 and fix issue with `docker compose ps`

### DIFF
--- a/.changeset/strong-rules-wave.md
+++ b/.changeset/strong-rules-wave.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+bump minimum docker compose version to 2.21.0 (docker breaking change)

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -9,17 +9,17 @@ export default class DoctorCommand extends Command {
     static examples = ["<%= config.bin %> <%= command.id %>"];
 
     private static MINIMUM_DOCKER_VERSION = "23.0.0"; // Replace with our minimum required Docker version
-    private static MINIMUM_DOCKER_COMPOSE_VERSION = "2.16.0"; // Replace with our minimum required Docker Compose version
+    private static MINIMUM_DOCKER_COMPOSE_VERSION = "2.21.0"; // Replace with our minimum required Docker Compose version
 
     private static isDockerVersionValid(version: string): boolean {
         return semver.gte(version, DoctorCommand.MINIMUM_DOCKER_VERSION);
     }
 
     private static isDockerComposeVersionValid(version: string): boolean {
-        const cleanedVersion = version.replace(/^v/, ""); // Remove leading 'v' if present
-        return semver.gte(
-            cleanedVersion,
-            DoctorCommand.MINIMUM_DOCKER_COMPOSE_VERSION
+        const v = semver.coerce(version);
+        return (
+            v !== null &&
+            semver.gte(v, DoctorCommand.MINIMUM_DOCKER_COMPOSE_VERSION)
         );
     }
 
@@ -39,14 +39,14 @@ export default class DoctorCommand extends Command {
 
             if (!DoctorCommand.isDockerVersionValid(dockerVersion)) {
                 throw new Error(
-                    `Unsupported Docker version. Minimum required version is ${DoctorCommand.MINIMUM_DOCKER_VERSION}. Installed version is ${dockerVersion}.`
+                    `Unsupported Docker version. Minimum required version is ${DoctorCommand.MINIMUM_DOCKER_VERSION}. Installed version is ${dockerVersion}.`,
                 );
             }
 
             // Check Docker Compose version
             const { stdout: dockerComposeVersionOutput } = await execa(
                 "docker",
-                ["compose", "version", "--short"]
+                ["compose", "version", "--short"],
             );
             const dockerComposeVersion = dockerComposeVersionOutput.trim();
 
@@ -54,7 +54,7 @@ export default class DoctorCommand extends Command {
                 !DoctorCommand.isDockerComposeVersionValid(dockerComposeVersion)
             ) {
                 throw new Error(
-                    `Unsupported Docker Compose version. Minimum required version is ${DoctorCommand.MINIMUM_DOCKER_COMPOSE_VERSION}. Installed version is ${dockerComposeVersion}.`
+                    `Unsupported Docker Compose version. Minimum required version is ${DoctorCommand.MINIMUM_DOCKER_COMPOSE_VERSION}. Installed version is ${dockerComposeVersion}.`,
                 );
             }
 
@@ -68,7 +68,7 @@ export default class DoctorCommand extends Command {
 
             if (!buildxRiscv64Supported) {
                 throw new Error(
-                    "Your system does not support riscv64 architecture."
+                    "Your system does not support riscv64 architecture.",
                 );
             }
 

--- a/apps/cli/src/sunodoCommand.ts
+++ b/apps/cli/src/sunodoCommand.ts
@@ -51,7 +51,7 @@ export abstract class SunodoCommand<T extends typeof Command> extends Command {
             "json",
         ]);
         const ps = JSON.parse(stdout) as PsResponse;
-        return ps.length > 0 ? ps[0].State : undefined;
+        return ps?.State;
     }
 
     protected async getDAppAddress(): Promise<Address | undefined> {

--- a/apps/cli/src/types/docker.ts
+++ b/apps/cli/src/types/docker.ts
@@ -20,4 +20,4 @@ export type ServicePublisher = {
     Protocol: string;
 };
 
-export type PsResponse = ServiceStatus[];
+export type PsResponse = ServiceStatus;


### PR DESCRIPTION
The newest version of Docker compose 2.21 introduced a breaking change to the `docker compose ps --format json` command, that now returns a single status object instead of an array of status objects.

https://github.com/docker/compose/pull/10918

This PR fixes the check of the minimum version of Docker compose by the `sunodo doctor` command, sets the minimum version to `2.21` and fixes the behavior of `sunodo address-book` which depends on `docker compose ps`.

Users upgrading sunodo with this change must also make sure they have the new minimum required Docker compose version.