### PR TITLE
ci(cli): release npm package

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -1,8 +1,10 @@
 name: cli
 on:
-    push:
-        tags:
-            - "@sunodo/cli@*"
+    workflow_call:
+        inputs:
+            do-release:
+                type: boolean
+                required: false
     pull_request:
         paths:
             - .github/workflows/cli.yaml
@@ -30,6 +32,7 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: 20
+                  registry-url: "https://registry.npmjs.org"
                   cache: "yarn"
 
             - name: Install Foundry
@@ -40,3 +43,10 @@ jobs:
 
             - name: Build
               run: yarn build --filter @sunodo/cli
+
+            - name: Publish
+              if: ${{ inputs.do-release == 'true' }}
+              working-directory: ./apps/cli
+              run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,3 +87,11 @@ jobs:
         needs: [release, packages_to_build]
         if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'contracts') }}
         uses: ./.github/workflows/contracts.yaml
+
+    build_cli:
+        name: Build cli
+        needs: [release, packages_to_build]
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'cli') }}
+        uses: ./.github/workflows/cli.yaml
+        with:
+            do-release: true


### PR DESCRIPTION
This PR should enable the publish of the `@sunodo/cli` NPM package only if the `release` CI workflow has a changeset release for the `@sunodo/cli` package.