### PR TITLE
Fix release workflow for cli and contracts

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -1,6 +1,10 @@
 name: contracts
 on:
     workflow_call:
+        inputs:
+            do-release:
+                type: boolean
+                required: false
     pull_request:
         paths:
             - .github/workflows/contracts.yaml
@@ -39,7 +43,7 @@ jobs:
               run: yarn build --filter=contracts
 
             - name: Publish package
-              if: startsWith(github.ref, 'refs/tags/@sunodo/contracts@')
+              if: ${{ inputs.do-release == 'true' }}
               run: npm publish --access public
               working-directory: packages/contracts
               env:
@@ -47,7 +51,7 @@ jobs:
 
             - name: Upload to release
               uses: softprops/action-gh-release@v1
-              if: startsWith(github.ref, 'refs/tags/@sunodo/contracts@')
+              if: ${{ inputs.do-release == 'true' }}
               with:
                   body_path: packages/contracts/CHANGELOG.md
                   files: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,13 +85,15 @@ jobs:
     build_contracts:
         name: Build contracts
         needs: [release, packages_to_build]
-        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'contracts') }}
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@sunodo/contracts') }}
         uses: ./.github/workflows/contracts.yaml
+        with:
+            do-release: true
 
     build_cli:
         name: Build cli
         needs: [release, packages_to_build]
-        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), 'cli') }}
+        if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@sunodo/cli') }}
         uses: ./.github/workflows/cli.yaml
         with:
             do-release: true


### PR DESCRIPTION
Fix the release workflow for the cli package, which name is `@sunodo/cli`.
Also follows the same strategy for publishing of the `@sunodo/contracts` package.
