### PR TITLE
Revert "feat(rollups-node): bump to cartesi/rollups-node:1.1.0"

### DIFF
--- a/.changeset/eighty-jokes-own.md
+++ b/.changeset/eighty-jokes-own.md
@@ -1,5 +1,0 @@
----
-"rollups-node": minor
----
-
-use cartesi/rollups-node:1.1.0

--- a/apps/cli/src/node/docker-compose-dev.yml
+++ b/apps/cli/src/node/docker-compose-dev.yml
@@ -1,5 +1,12 @@
 version: "3.9"
 
+x-database-config: &database-config
+    POSTGRES_HOSTNAME: database
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: password
+    POSTGRES_DB: postgres
+
 services:
     anvil:
         image: sunodo/devnet:1.1.0
@@ -106,7 +113,7 @@ services:
             REMOTE_CARTESI_MACHINE_LOG_LEVEL: "${REMOTE_CARTESI_MACHINE_LOG_LEVEL:-info}"
 
             ### database
-            POSTGRES_ENDPOINT: "${POSTGRES_ENDPOINT:-postgres://postgres:password@database:5432/postgres}"
+            <<: *database-config
 
             # dispatcher
             ## uses redis
@@ -122,7 +129,7 @@ services:
             TX_DEFAULT_CONFIRMATIONS: 2
 
             # state-server
-            SF_GENESIS_BLOCK: 1
+            SF_GENESIS_BLOCK: 0x1
             SF_SAFETY_MARGIN: 1
             BH_HTTP_ENDPOINT: http://anvil:8545
             BH_WS_ENDPOINT: ws://anvil:8545
@@ -134,7 +141,6 @@ services:
             ## uses session-id
             ## uses chain-id
             ## uses server-manager-endpoint
-            PROVIDER_HTTP_ENDPOINT: http://anvil:8545
             SNAPSHOT_DIR: "/var/opt/cartesi/machine-snapshots"
             SNAPSHOT_LATEST: "/var/opt/cartesi/machine-snapshots/latest"
 

--- a/packages/rollups-node/Dockerfile
+++ b/packages/rollups-node/Dockerfile
@@ -2,15 +2,20 @@
 ARG REGISTRY=docker.io
 ARG ORG=cartesi
 ARG ROLLUPS_VERSION
+FROM ${REGISTRY}/${ORG}/rollups-indexer:${ROLLUPS_VERSION}         AS indexer
+FROM ${REGISTRY}/${ORG}/rollups-state-server:${ROLLUPS_VERSION}    AS state_server
+FROM ${REGISTRY}/${ORG}/rollups-dispatcher:${ROLLUPS_VERSION}      AS dispatcher
+FROM ${REGISTRY}/${ORG}/rollups-advance-runner:${ROLLUPS_VERSION}  AS advance_runner
+FROM ${REGISTRY}/${ORG}/rollups-inspect-server:${ROLLUPS_VERSION}  AS inspect_server
+FROM ${REGISTRY}/${ORG}/rollups-graphql-server:${ROLLUPS_VERSION}  AS graphql_server
+FROM ${REGISTRY}/${ORG}/rollups-host-runner:${ROLLUPS_VERSION}     AS host_runner
 
-FROM ${REGISTRY}/${ORG}/rollups-node:${ROLLUPS_VERSION}
-
+FROM cartesi/server-manager:0.8.2
 USER root
 
-ARG DEBIAN_FRONTEND="noninteractive"
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends \
+DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -39,6 +44,14 @@ tar -Jxpf "$tmp_dir"/s6-overlay-${ARCH}.tar.xz -C /
 cd -
 rm -rf "$tmp_dir"
 EOF
+
+COPY --from=state_server    /opt/cartesi/bin/cartesi-rollups-state-server   /usr/bin/cartesi-rollups-state-server
+COPY --from=indexer         /opt/cartesi/bin/cartesi-rollups-indexer        /usr/bin/cartesi-rollups-indexer
+COPY --from=dispatcher      /opt/cartesi/bin/cartesi-rollups-dispatcher     /usr/bin/cartesi-rollups-dispatcher
+COPY --from=advance_runner  /opt/cartesi/bin/cartesi-rollups-advance-runner /usr/bin/cartesi-rollups-advance-runner
+COPY --from=inspect_server  /opt/cartesi/bin/cartesi-rollups-inspect-server /usr/bin/cartesi-rollups-inspect-server
+COPY --from=graphql_server  /opt/cartesi/bin/cartesi-rollups-graphql-server /usr/bin/cartesi-rollups-graphql-server
+COPY --from=host_runner     /opt/cartesi/bin/cartesi-rollups-host-runner    /usr/bin/cartesi-rollups-host-runner
 
 RUN mkdir -p /var/opt/cartesi/machine-snapshots/0_0 && ln -s /var/opt/cartesi/machine-snapshots/0_0 /var/opt/cartesi/machine-snapshots/latest
 

--- a/packages/rollups-node/docker-bake.hcl
+++ b/packages/rollups-node/docker-bake.hcl
@@ -2,7 +2,7 @@ target "docker-metadata-action" {}
 target "docker-platforms" {}
 
 variable "ROLLUPS_VERSION" {
-  default = "1.1.0"
+  default = "1.0.2"
 }
 
 target "default" {


### PR DESCRIPTION
This reverts commit 0306b484dc92f0a77d50b6aeb934a5999658369b.