### PR TITLE
Prompt of running services

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -93,7 +93,7 @@
         "codegen": "run-p codegen:wagmi",
         "codegen:wagmi": "wagmi generate",
         "compile": "tsc -b",
-        "copy-files": "copyfiles -u 1 \"src/**/*.yaml\" dist",
+        "copy-files": "copyfiles -u 1 \"src/**/*.yaml\" \"src/**/*.txt\" dist",
         "lint": "eslint . --ext .ts --config .eslintrc",
         "postpack": "rimraf oclif.manifest.json",
         "posttest": "yarn lint",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -110,7 +110,9 @@ export default class Run extends Command {
             "--project-name",
             projectName,
         ];
-        const attachment = flags.verbose ? [] : ["--attach", "validator"];
+        const attachment = flags.verbose
+            ? []
+            : ["--attach", "validator", "--attach", "prompt"];
 
         // XXX: need this handler, so SIGINT can still call the finally block below
         process.on("SIGINT", () => {});

--- a/apps/cli/src/node/docker-compose-dev.yaml
+++ b/apps/cli/src/node/docker-compose-dev.yaml
@@ -160,11 +160,30 @@ services:
         depends_on:
             validator:
                 condition: service_healthy
+        healthcheck:
+            test: ["CMD", "traefik", "healthcheck"]
+            interval: 5s
+            timeout: 1s
+            retries: 5
         ports:
             - 8080:8080
-            - 8088:8088
         volumes:
             - ${SUNODO_BIN_PATH}/node/traefik:/etc/traefik
+
+    prompt:
+        image: debian:bookworm-slim
+        command:
+            [
+                "sh",
+                "-c",
+                "ls | sort | xargs cat; trap exit INT TERM; sleep infinity & wait",
+            ]
+        working_dir: /prompt
+        volumes:
+            - ${SUNODO_BIN_PATH}/node/prompt:/prompt
+        depends_on:
+            proxy:
+                condition: service_healthy
 
 volumes:
     blockchain-data: {}

--- a/apps/cli/src/node/prompt/01_anvil.txt
+++ b/apps/cli/src/node/prompt/01_anvil.txt
@@ -1,0 +1,1 @@
+Anvil running at http://localhost:8545

--- a/apps/cli/src/node/prompt/02_graphql.txt
+++ b/apps/cli/src/node/prompt/02_graphql.txt
@@ -1,0 +1,1 @@
+GraphQL running at http://localhost:8080/graphql

--- a/apps/cli/src/node/prompt/03_inspect.txt
+++ b/apps/cli/src/node/prompt/03_inspect.txt
@@ -1,0 +1,1 @@
+Inspect running at http://localhost:8080/inspect/

--- a/apps/cli/src/node/prompt/10_exit.txt
+++ b/apps/cli/src/node/prompt/10_exit.txt
@@ -1,0 +1,1 @@
+Press Ctrl+C to stop the node

--- a/apps/cli/src/node/traefik/traefik.yaml
+++ b/apps/cli/src/node/traefik/traefik.yaml
@@ -3,6 +3,7 @@ entryPoints:
         address: ":8080"
     traefik:
         address: ":8088"
+ping: {}
 providers:
     file:
         directory: /etc/traefik/conf.d


### PR DESCRIPTION
This is how it looks:

```
79c354a7-validator-1  | host-runner: ENABLE_SUNODO_NODE is not set, skip the host mode...
79c354a7-validator-1  | Provisioning cartesi-machine snapshot...
79c354a7-prompt-1     | Anvil running at http://localhost:8545
79c354a7-prompt-1     | GraphQL running at http://localhost:8080/graphql
79c354a7-prompt-1     | Inspect running at http://localhost:8080/inspect/
79c354a7-prompt-1     | Press Ctrl+C to stop the node
79c354a7-prompt-1 exited with code 0
```

I'm not super happy with the last line, because it may give the user the impression something went wrong.
Any suggestion?
