### PR TITLE
Simplify release build of cli

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -99,7 +99,7 @@
         "posttest": "yarn lint",
         "prepack": "yarn build && oclif manifest && oclif readme",
         "test": "vitest",
-        "version": "run-s prepack"
+        "version": "oclif manifest && oclif readme"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
The changeset action, on release, runs `yarn run version-packages`

That, according to `package.json` target, runs `yarn changeset version && turbo run version`

`turbo run version` runs the `version` target of `cli`, with the goal to update the cli `README.md` file, which contains the version number.

In this PR I change that target to only run `oclif manifest && oclif readme`, which in fact update the `README.md`, and remove the `build` step.
