### PR TITLE
Fix release check in CI workflows

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -2,7 +2,7 @@ name: cli
 on:
     workflow_call:
         inputs:
-            do-release:
+            release:
                 type: boolean
                 required: false
         secrets:
@@ -50,7 +50,7 @@ jobs:
               run: yarn build --filter @sunodo/cli
 
             - name: Publish
-              if: ${{ inputs.do-release == 'true' }}
+              if: ${{ inputs.release }}
               working-directory: ./apps/cli
               run: npm publish
               env:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -2,7 +2,7 @@ name: contracts
 on:
     workflow_call:
         inputs:
-            do-release:
+            release:
                 type: boolean
                 required: false
         secrets:
@@ -48,7 +48,7 @@ jobs:
               run: yarn build --filter=contracts
 
             - name: Publish package
-              if: ${{ inputs.do-release == 'true' }}
+              if: ${{ inputs.release }}
               run: npm publish --access public
               working-directory: packages/contracts
               env:
@@ -56,7 +56,7 @@ jobs:
 
             - name: Upload to release
               uses: softprops/action-gh-release@v1
-              if: ${{ inputs.do-release == 'true' }}
+              if: ${{ inputs.release }}
               with:
                   body_path: packages/contracts/CHANGELOG.md
                   files: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: ./.github/workflows/contracts.yaml
         secrets: inherit
         with:
-            do-release: true
+            release: true
 
     build_cli:
         name: Build cli
@@ -101,4 +101,4 @@ jobs:
         uses: ./.github/workflows/cli.yaml
         secrets: inherit
         with:
-            do-release: true
+            release: true


### PR DESCRIPTION
Check of boolean inputs must not be with `'true'` string.
Also changed the variable name from `do-release` to only `release`, to be on the safe side.
