### PR TITLE
fix: docker compose volumes for different sunodo run options

### DIFF
--- a/.changeset/rare-bikes-grin.md
+++ b/.changeset/rare-bikes-grin.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+add docker compose snapshot volumes for different sunodo run options

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -87,12 +87,18 @@ export default class Run extends Command {
         // dev file is always loaded
         const composeFiles = ["docker-compose-dev.yaml"];
 
+        // snapshot volume
+        composeFiles.push("docker-compose-snapshot-volume.yaml");
+
         // explorer
         composeFiles.push("docker-compose-explorer.yaml");
 
         // load the no-backend compose file
         if (flags["no-backend"]) {
             composeFiles.push("docker-compose-host.yaml");
+        } else {
+            // snapshot volume
+            composeFiles.push("docker-compose-snapshot-volume.yaml");
         }
 
         // add project env file loading

--- a/apps/cli/src/node/docker-compose-dev.yaml
+++ b/apps/cli/src/node/docker-compose-dev.yaml
@@ -66,7 +66,6 @@ services:
             ]
         volumes:
             - blockchain-data:/usr/share/sunodo
-            - ./.sunodo/image:/var/opt/cartesi/machine-snapshots/0_0:ro
 
     validator:
         image: sunodo/rollups-node:0.5.0
@@ -75,7 +74,6 @@ services:
                 condition: service_completed_successfully
         volumes:
             - blockchain-data:/usr/share/sunodo:ro
-            - ./.sunodo/image:/tmp/machine-snapshots/0_0:ro
         healthcheck:
             test: ["CMD", "is_ready"]
             interval: 10s

--- a/apps/cli/src/node/docker-compose-snapshot-volume.yaml
+++ b/apps/cli/src/node/docker-compose-snapshot-volume.yaml
@@ -1,0 +1,10 @@
+version: "3.9"
+
+services:
+    dapp_deployer:
+        volumes:
+            - ./.sunodo/image:/var/opt/cartesi/machine-snapshots/0_0:ro
+
+    validator:
+        volumes:
+            - ./.sunodo/image:/tmp/machine-snapshots/0_0:ro


### PR DESCRIPTION
/close #245 
This PR adds another Docker Compose file named docker-compose-snapshot-volume.yaml. This file includes snapshot volumes for the validator and dapp_deployer services and is used with the sunodo run command, except when the --no-backend option is used."