### PR TITLE
Bump anvil version

### DIFF
--- a/.changeset/beige-pans-fly.md
+++ b/.changeset/beige-pans-fly.md
@@ -1,0 +1,5 @@
+---
+"anvil": minor
+---
+
+bump anvil version to 0.2.0 (e0722a1 2023-10-10T00:24:58.269937466Z)

--- a/packages/anvil/Dockerfile
+++ b/packages/anvil/Dockerfile
@@ -9,7 +9,8 @@ rm -rf /var/lib/apt/lists/*
 EOF
 
 # download pre-compiled binaries
-RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
+ARG ANVIL_VERSION=e0722a10b45859892ec3b998df958a9edc77c202
+RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${ANVIL_VERSION}/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
     tar -zx -C /usr/local/bin
 
 # healthcheck script using net_listening JSON-RPC method


### PR DESCRIPTION
Bump anvil version to anvil 0.2.0 (e0722a1 2023-10-10T00:24:58.269937466Z)

Solves issue https://github.com/foundry-rs/foundry/issues/5917