### PR TITLE
chore(anvil): fix anvil changeset

### DIFF
--- a/.changeset/late-dryers-burn.md
+++ b/.changeset/late-dryers-burn.md
@@ -1,5 +1,5 @@
 ---
-"@sunodo/cli": patch
+"anvil": minor
 ---
 
 update anvil nightly version


### PR DESCRIPTION
I know this also fixes the build of the entire project, but the main thing of the changeset is to introduce a new release of the anvil image. The changeset of the CLI comes later.