### PR TITLE
fix(web): package renamed

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
         "react": "^18.2",
         "react-dom": "^18.2",
         "tss-react": "^4.8",
-        "ui": "*"
+        "@sunodo/ui": "*"
     },
     "devDependencies": {
         "@babel/core": "^7",


### PR DESCRIPTION
When internal packages were renamed at https://github.com/sunodo/sunodo/pull/286, we forgot to rename the dependency
