### PR TITLE
feat(cli): sync advance-runner and s6-rc timeouts

### DIFF
--- a/.changeset/lazy-news-beg.md
+++ b/.changeset/lazy-news-beg.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+sync advance-runner and s6-rc timeouts

--- a/apps/cli/src/node/default.env
+++ b/apps/cli/src/node/default.env
@@ -1,6 +1,7 @@
 # s6-overlay
 S6_STAGE2_HOOK="/etc/s6-overlay/scripts/stage2-hook.sh"
 S6_VERBOSITY="${S6_VERBOSITY:-2}"
+S6_CMD_WAIT_FOR_SERVICES_MAXTIME=${SM_DEADLINE_MACHINE:-30000}
 # global
 RUST_LOG="${RUST_LOG:-info}"
 ## shared


### PR DESCRIPTION
This PR will define the `S6_CMD_WAIT_FOR_SERVICES_MAXTIME` using the default value for `SM_DEADLINE_MACHINE`, which is `30000` (in milliseconds).

In case the user provides a different value for `SM_DEADLINE_MACHINE`, it will be used by `S6_CMD_WAIT_FOR_SERVICES_MAXTIME`.

This error should be solved:

```
36eb741f-validator-1  | s6-rc: fatal: timed out
36eb741f-validator-1  | s6-sudoc: fatal: unable to get exit status from server: Operation timed out
```