### PR TITLE
feat(cli): adapt to sunodo/rollups-node:0.6.0

### DIFF
--- a/.changeset/lucky-flies-reflect.md
+++ b/.changeset/lucky-flies-reflect.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+adapt to sunodo/rollups-node:0.6.0

--- a/apps/cli/src/node/default.env
+++ b/apps/cli/src/node/default.env
@@ -6,7 +6,7 @@ S6_CMD_WAIT_FOR_SERVICES_MAXTIME=${SM_DEADLINE_MACHINE:-30000}
 RUST_LOG="${RUST_LOG:-info}"
 ## shared
 ### redis
-REDIS_ENDPOINT=redis://redis:6379
+REDIS_ENDPOINT=${REDIS_ENDPOINT:-redis://127.0.0.1:6379}
 ### contract-address-file
 DAPP_CONTRACT_ADDRESS_FILE=/usr/share/sunodo/dapp.json
 ### session-id
@@ -19,22 +19,29 @@ SERVER_MANAGER_ENDPOINT=http://localhost:5001
 SERVER_MANAGER_ADDRESS=localhost:5001
 SERVER_MANAGER_LOG_LEVEL="${SERVER_MANAGER_LOG_LEVEL:-info}"
 REMOTE_CARTESI_MACHINE_LOG_LEVEL="${REMOTE_CARTESI_MACHINE_LOG_LEVEL:-info}"
+### state-server-endpoint
+SC_GRPC_ENDPOINT=http://localhost:50051
 
 ### database
 POSTGRES_ENDPOINT="${POSTGRES_ENDPOINT:-postgres://postgres:password@database:5432/postgres}"
 
 # dispatcher
 ## uses redis
-## uses chain-id (TX_CHAIN_ID acctually)
-AUTH_MNEMONIC="test test test test test test test test test test test junk"
-RD_DAPP_DEPLOYMENT_FILE=/usr/share/sunodo/dapp.json
-RD_ROLLUPS_DEPLOYMENT_FILE=/usr/share/sunodo/localhost.json
+## uses chain-id
+## uses state-server-endpoint
+DAPP_DEPLOYMENT_FILE=/usr/share/sunodo/dapp.json
+ROLLUPS_DEPLOYMENT_FILE=/usr/share/sunodo/localhost.json
 RD_EPOCH_DURATION="${RD_EPOCH_DURATION:-86400}"
-SC_GRPC_ENDPOINT=http://localhost:50051
 SC_DEFAULT_CONFIRMATIONS=1
+
+# authority-claimer
+## uses redis
+## uses state-server-endpoint
+## uses chain-id (TX_CHAIN_ID acctually)
+TX_CHAIN_IS_LEGACY: "false"
+TX_DEFAULT_CONFIRMATIONS: "2"
+TX_SIGNING_MNEMONIC="test test test test test test test test test test test junk"
 TX_PROVIDER_HTTP_ENDPOINT=http://anvil:8545
-TX_CHAIN_IS_LEGACY=${TX_LEGACY:-false}
-TX_DEFAULT_CONFIRMATIONS=2
 
 # state-server
 SF_GENESIS_BLOCK=1

--- a/apps/cli/src/node/docker-compose-dev.yaml
+++ b/apps/cli/src/node/docker-compose-dev.yaml
@@ -34,16 +34,6 @@ services:
         environment:
             - POSTGRES_PASSWORD=password
 
-    redis:
-        image: redis:6-alpine
-        restart: always
-        command: ["--loglevel", "${REDIS_LOG_LEVEL:-warning}"]
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            interval: 10s
-            timeout: 5s
-            retries: 5
-
     dapp_deployer:
         image: cartesi/rollups-cli:1.0.2
         restart: on-failure


### PR DESCRIPTION
This PR will make `sunodo run` work with sunodo/rollups-node:0.6.0

Since a redis service is part of the sunodo/rollups-node:0.6.0, it was removed from the compose file.

If the user needs to connect to another redis that not the one provided inside the rollups-node, they can define an alternative `REDIS_ENDPOINT` via `.sunodo.env`.

Depends on: #293 and @sunodo/rollups-node:0.6.0 release.