### PR TITLE
Start command (patch namespace)

### DIFF
--- a/apps/cli/src/k8s/traefik/templates/dashboard-ingressroute.yaml
+++ b/apps/cli/src/k8s/traefik/templates/dashboard-ingressroute.yaml
@@ -4,11 +4,11 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: traefik-dashboard
-  namespace: default
+  namespace: sunodo-31337
   annotations:
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/apps/cli/src/k8s/traefik/templates/deployment.yaml
+++ b/apps/cli/src/k8s/traefik/templates/deployment.yaml
@@ -4,10 +4,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: traefik
-  namespace: default
+  namespace: sunodo-31337
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: traefik
-      app.kubernetes.io/instance: traefik-default
+      app.kubernetes.io/instance: traefik-sunodo-31337
   strategy: 
     rollingUpdate:
       maxSurge: 1
@@ -31,7 +31,7 @@ spec:
         prometheus.io/port: "9100"
       labels:
         app.kubernetes.io/name: traefik
-        app.kubernetes.io/instance: traefik-default
+        app.kubernetes.io/instance: traefik-sunodo-31337
         helm.sh/chart: traefik-25.0.0
         app.kubernetes.io/managed-by: Helm
     spec:

--- a/apps/cli/src/k8s/traefik/templates/ingressclass.yaml
+++ b/apps/cli/src/k8s/traefik/templates/ingressclass.yaml
@@ -7,7 +7,7 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
   name: traefik

--- a/apps/cli/src/k8s/traefik/templates/rbac/clusterrole.yaml
+++ b/apps/cli/src/k8s/traefik/templates/rbac/clusterrole.yaml
@@ -3,10 +3,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: traefik-default
+  name: traefik-sunodo-31337
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
 rules:

--- a/apps/cli/src/k8s/traefik/templates/rbac/clusterrolebinding.yaml
+++ b/apps/cli/src/k8s/traefik/templates/rbac/clusterrolebinding.yaml
@@ -3,17 +3,17 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: traefik-default
+  name: traefik-sunodo-31337
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: traefik-default
+  name: traefik-sunodo-31337
 subjects:
   - kind: ServiceAccount
     name: traefik
-    namespace: default
+    namespace: sunodo-31337

--- a/apps/cli/src/k8s/traefik/templates/rbac/serviceaccount.yaml
+++ b/apps/cli/src/k8s/traefik/templates/rbac/serviceaccount.yaml
@@ -4,10 +4,10 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: traefik
-  namespace: default
+  namespace: sunodo-31337
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
   annotations:

--- a/apps/cli/src/k8s/traefik/templates/service.yaml
+++ b/apps/cli/src/k8s/traefik/templates/service.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: traefik
-  namespace: default
+  namespace: sunodo-31337
   labels:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
     helm.sh/chart: traefik-25.0.0
     app.kubernetes.io/managed-by: Helm
   annotations:
@@ -15,7 +15,7 @@ spec:
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: traefik
-    app.kubernetes.io/instance: traefik-default
+    app.kubernetes.io/instance: traefik-sunodo-31337
   ports:
   - port: 80
     name: "web"


### PR DESCRIPTION
This shows that this strategy of patching templates generated by helm is not very nice.
Traefik when installed in a different namespace, needs more patches, especially related to RBAC.