### PR TITLE
Fix contracts npm publishing

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -35,6 +35,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  registry-url: "https://registry.npmjs.org"
                   cache: "yarn"
 
             - name: Install Foundry


### PR DESCRIPTION
For npm publishing to work with the env variable we need to explicitly set the registry-url of the setup-node action, according to https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

> Please note that you need to set the registry-url to https://registry.npmjs.org/ in setup-node to properly configure your credentials.