### PR TITLE
feat: call homebrew-tap Dispatch workflow

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -55,3 +55,10 @@ jobs:
               run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Call homebrew-tap Repository Dispatch
+              uses: peter-evans/repository-dispatch@v2
+              with:
+                token: ${{ secrets.HOMEBREW_TAP_PAT }}
+                repository: sunodo/homebrew-tap
+                event-type: update-package


### PR DESCRIPTION
This PR added a `Repository Dispatcher` section to call the `sunodo/homebrew-tap` workflows to automate the NPM package update process. 

We just need to generate a `Fine-grained personal access tokens` and set it on github secrets. 