### PR TITLE
feat(cli): copy files from container instead of bind mount

### DIFF
--- a/.changeset/beige-parents-check.md
+++ b/.changeset/beige-parents-check.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+fix .sunodo/ files permissions (#352)

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -222,19 +222,6 @@ export default class BuildApplication extends Command {
         const ramSize = info.ramSize;
         const driveLabel = "root"; // XXX: does this need to be customizable?
 
-        // su, variables to run container as current user
-        const user = os.userInfo();
-        const su = [
-            "--env",
-            `USER=${user.username}`,
-            "--env",
-            `GROUP=container-group-${user.gid}`,
-            "--env",
-            `UID=${user.uid}`,
-            "--env",
-            `GID=${user.gid}`,
-        ];
-
         // list of environment variables of docker image
         // XXX: we can't include all of them because cartesi-machine command has length limits
         const envs = info.env.filter((variable) => {


### PR DESCRIPTION
When using bind mount, we can have problems with permissions for the files at the host and inside the container, and the behavior is different when using Docker Desktop for {Linux, macOs} and Docker Engine on a Linux host.

/close #352