### PR TITLE
Fix token initial mint

### DIFF
--- a/.changeset/fifty-singers-nail.md
+++ b/.changeset/fifty-singers-nail.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/token": minor
+---
+
+change initial mint to the initial authority

--- a/packages/token/contracts/SunodoToken.sol
+++ b/packages/token/contracts/SunodoToken.sol
@@ -22,7 +22,7 @@ contract SunodoToken is
         AccessManaged(initialAuthority)
         ERC20Permit("SunodoToken")
     {
-        _mint(msg.sender, 1000000000 * 10 ** decimals());
+        _mint(initialAuthority, 1000000000 * 10 ** decimals());
     }
 
     function pause() public restricted {


### PR DESCRIPTION
I was minting the initial amount to the `msg.sender` of the deployer of the contract.
This was causing a problem with the deterministic deployment, because the `msg.sender` in that case was the smart contract that actually does the deployment, which was the account used by https://github.com/safe-global/safe-singleton-factory.
This changes the recipient of the initial mint to the initial authority of the contract, which is the one that has minting power anyway, so it works just fine.
