### PR TITLE
Improve reproducible build

### DIFF
--- a/.changeset/kind-nails-tease.md
+++ b/.changeset/kind-nails-tease.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+make builds reproducible

--- a/.changeset/modern-mirrors-shake.md
+++ b/.changeset/modern-mirrors-shake.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/sdk": minor
+---
+
+add undocker to extract rootfs from container image

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -3,6 +3,7 @@ import bytes from "bytes";
 import { execa } from "execa";
 import fs from "fs-extra";
 import path from "path";
+import semver from "semver";
 import tmp from "tmp";
 
 type ImageBuildOptions = {
@@ -111,6 +112,22 @@ export default class BuildApplication extends Command {
 
         if (!info.entrypoint && !info.cmd) {
             throw new Error("Undefined image ENTRYPOINT or CMD");
+        }
+
+        // fail if using unsupported sdk version
+        if (!semver.valid(info.sdkVersion)) {
+            this.warn("sunodo sdk version is not a valid semver");
+        } else if (semver.lt(info.sdkVersion, SUNODO_DEFAULT_SDK_VERSION)) {
+            throw new Error(`Unsupported sunodo sdk version.
+
+Make sure you defined \`io.sunodo.sdk_version\` label at your Dockerfile.
+
+It shoud be >= ${SUNODO_DEFAULT_SDK_VERSION}.
+
+Eg.:
+
+LABEL io.sunodo.sdk_version=${SUNODO_DEFAULT_SDK_VERSION}
+`);
         }
 
         // warn for using default values

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 ARG BASE_IMAGE
 ARG MACHINE_EMULATOR_VERSION
 ARG LINUX_VERSION
@@ -38,6 +38,12 @@ curl -sL https://github.com/ncopa/su-exec/archive/f85e5bde1afef399021fbc2a99c837
 make
 EOF
 
+# undocker
+FROM golang:1.21-bookworm as undocker
+ADD --keep-git-dir=true https://git.jakstys.lt/motiejus/undocker.git#v1.2.0 /undocker
+WORKDIR /undocker
+RUN make undocker
+
 # sdk image
 FROM cartesi/machine-emulator:$MACHINE_EMULATOR_VERSION
 ARG MACHINE_EMULATOR_VERSION
@@ -65,6 +71,8 @@ COPY entrypoint.sh /usr/local/bin/
 COPY retar /usr/local/bin/
 COPY --from=genext2fs /usr/local/bin/genext2fs /usr/bin/
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
+COPY --from=undocker /undocker/undocker /usr/local/bin/
+RUN mkdir -p /tmp/.sunodo && chmod 1777 /tmp/.sunodo
 
 ADD --chmod=644 \
     https://github.com/cartesi/image-kernel/releases/download/v$LINUX_VERSION/linux-$LINUX_KERNEL_VERSION.bin \

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -9,6 +9,7 @@ FROM ${BASE_IMAGE} as builder
 
 WORKDIR /usr/local/src
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends autoconf automake build-essential ca-certificates curl libarchive-dev libtool
 rm -rf /var/lib/apt/lists/*
@@ -19,6 +20,7 @@ FROM builder as genext2fs
 WORKDIR /usr/local/src
 ARG GENEXT2FS_VERSION=1.5.2
 RUN <<EOF
+set -e
 curl -sL https://github.com/cartesi/genext2fs/archive/refs/tags/v${GENEXT2FS_VERSION}.tar.gz | tar --strip-components=1 -zxvf -
 ./autogen.sh
 ./configure --enable-libarchive
@@ -31,6 +33,7 @@ FROM builder as su-exec
 # v0.2 -> f85e5bde1afef399021fbc2a99c837cf851ceafa
 WORKDIR /usr/local/src
 RUN <<EOF
+set -e
 curl -sL https://github.com/ncopa/su-exec/archive/f85e5bde1afef399021fbc2a99c837cf851ceafa.tar.gz | tar --strip-components=1 -zxvf -
 make
 EOF
@@ -44,6 +47,7 @@ ARG ROM_VERSION
 
 USER root
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends curl libarchive-tools locales xz-utils
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR will add `undocker` to the sunodo/sdk image, so it solve the problem reported at #330, where the `docker container create` step introduces files that makes final ext2 rootfs not reproducible.

/close #330 