### PR TITLE
fix(sdk): use patched undocker version

### DIFF
--- a/.changeset/plenty-starfishes-repeat.md
+++ b/.changeset/plenty-starfishes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/sdk": patch
+---
+
+fix undocker

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -39,8 +39,9 @@ make
 EOF
 
 # undocker
-FROM golang:1.21-bookworm as undocker
-ADD --keep-git-dir=true https://git.jakstys.lt/motiejus/undocker.git#v1.2.0 /undocker
+# v1.2.2 -> aca5cd2888497df02a89fbd5d27d57699e971d74
+FROM golang:1.22-bookworm as undocker
+ADD --keep-git-dir=true https://github.com/endersonmaia/undocker.git#aca5cd2888497df02a89fbd5d27d57699e971d74 /undocker
 WORKDIR /undocker
 RUN make undocker
 


### PR DESCRIPTION
After using the new undocker package, to solve the reproducibility issue, I found that it was failing, but I con't identify why if was OK in the past and when it started failing.

The project we used is not maintained [^1] anymore, so I had to fix it on my own fork [^2] and point at it.

In the future, it will be better if we implement this in TypeScript.

[^1]: https://git.jakstys.lt/motiejus/undocker#project-status
[^2]: https://github.com/endersonmaia/undocker