### PR TITLE
Remove undocker dependency

### DIFF
--- a/.changeset/lemon-books-arrive.md
+++ b/.changeset/lemon-books-arrive.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+remove undocker dependency

--- a/.changeset/yellow-elephants-lay.md
+++ b/.changeset/yellow-elephants-lay.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/sdk": patch
+---
+
+remove undocker dependency

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -38,13 +38,6 @@ curl -sL https://github.com/ncopa/su-exec/archive/f85e5bde1afef399021fbc2a99c837
 make
 EOF
 
-# undocker
-# v1.2.2 -> aca5cd2888497df02a89fbd5d27d57699e971d74
-FROM golang:1.22-bookworm as undocker
-ADD --keep-git-dir=true https://github.com/endersonmaia/undocker.git#aca5cd2888497df02a89fbd5d27d57699e971d74 /undocker
-WORKDIR /undocker
-RUN make undocker
-
 # sdk image
 FROM cartesi/machine-emulator:$MACHINE_EMULATOR_VERSION
 ARG MACHINE_EMULATOR_VERSION
@@ -72,7 +65,6 @@ COPY entrypoint.sh /usr/local/bin/
 COPY retar /usr/local/bin/
 COPY --from=genext2fs /usr/local/bin/genext2fs /usr/bin/
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
-COPY --from=undocker /undocker/undocker /usr/local/bin/
 RUN mkdir -p /tmp/.sunodo && chmod 1777 /tmp/.sunodo
 
 ADD --chmod=644 \

--- a/packages/sdk/retar
+++ b/packages/sdk/retar
@@ -1,7 +1,25 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
-TAR=$1
+
+TAR_IN="$1"; shift
+TAR_OUT="$1"; shift
+
+# https://reproducible-builds.org/docs/archives/
+TMP_DIR="$(mktemp -d)"
+tar -xf "$TAR_IN" -C "$TMP_DIR/"
+(
+    cd "$TMP_DIR"
+    tar \
+        --sort=name \
+        --mtime="@0" \
+        --numeric-owner \
+        --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+        -cf "$TAR_OUT" .
+)
+rm -rf "$TMP_DIR"
+
+# re-tar as gnu format, issue with locale
 TMP=$(mktemp)
-cp $TAR $TMP
-bsdtar -cf $TAR --format=gnutar @$TMP
-rm $TMP
+cp "$TAR_OUT" "$TMP"
+bsdtar -cf "$TAR_OUT" --format=gnutar @$TMP
+rm "$TMP"


### PR DESCRIPTION
This issue will replace the `undocker` with a `tar` command that helps on the reproducibility.

The motivation is that `undocker` is an unmaintained piece of software and we shouldn't rely on it.

The solution adopted is documented at https://reproducible-builds.org/docs/archives/