### PR TITLE
Packages missing rimraf for clean task

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -36,6 +36,7 @@
         "hardhat-abi-exporter": "^2",
         "hardhat-deploy": "^0.11",
         "npm-run-all": "^4",
+        "rimraf": "^5",
         "solidity-docgen": "^0.6.0-beta.36",
         "typescript": "^5",
         "viem": "^2.7.13"

--- a/packages/devnet/package.json
+++ b/packages/devnet/package.json
@@ -26,6 +26,7 @@
         "hardhat-abi-exporter": "^2",
         "hardhat-deploy": "^0.11",
         "npm-run-all": "^4",
+        "rimraf": "^5",
         "tsconfig": "workspace:*",
         "typescript": "^5"
     },

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -33,6 +33,7 @@
         "hardhat": "^2",
         "hardhat-deploy": "^0.11",
         "npm-run-all": "^4",
+        "rimraf": "^5",
         "typescript": "^5",
         "viem": "^2.7.13"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,9 @@ importers:
       npm-run-all:
         specifier: ^4
         version: 4.1.5
+      rimraf:
+        specifier: ^5
+        version: 5.0.5
       solidity-docgen:
         specifier: ^0.6.0-beta.36
         version: 0.6.0-beta.36(hardhat@2.20.1)
@@ -449,6 +452,9 @@ importers:
       npm-run-all:
         specifier: ^4
         version: 4.1.5
+      rimraf:
+        specifier: ^5
+        version: 5.0.5
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
@@ -502,6 +508,9 @@ importers:
       npm-run-all:
         specifier: ^4
         version: 4.1.5
+      rimraf:
+        specifier: ^5
+        version: 5.0.5
       typescript:
         specifier: ^5
         version: 5.3.3
@@ -15387,11 +15396,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /lru-cache@10.0.1:
-    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
-    engines: {node: 14 || >=16.14}
-    dev: true
-
   /lru-cache@10.2.0:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
@@ -17426,7 +17430,7 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 10.0.1
+      lru-cache: 10.2.0
       minipass: 7.0.4
     dev: true
 


### PR DESCRIPTION
After migration to pnpm, rimraf is missing from some packages.

ps: I don't think we need a changeset for this.
