### PR TITLE
chore(rollups-node): remove changeset for package

### DIFF
--- a/.changeset/nasty-sloths-suffer.md
+++ b/.changeset/nasty-sloths-suffer.md
@@ -1,5 +1,0 @@
----
-"@sunodo/rollups-node": minor
----
-
-adapt to cartesi/rollups-node:1.3.1


### PR DESCRIPTION
CI was failing since we have removed the @sunodo/rollups-node package but didn't removed changeset files mentioning it.

See: https://github.com/sunodo/sunodo/actions/runs/8300758063/job/22719357036#step:7:21