### PR TITLE
Fix no-backend mode fix

### DIFF
--- a/.changeset/few-trains-dress.md
+++ b/.changeset/few-trains-dress.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+fix no-backend mode

--- a/apps/cli/src/node/docker-compose-host.yaml
+++ b/apps/cli/src/node/docker-compose-host.yaml
@@ -1,21 +1,5 @@
 version: "3.9"
 services:
-    dapp_deployer:
-        command: [
-                "create",
-                "--rpc",
-                "http://anvil:8545",
-                "--deploymentFile",
-                "/usr/share/sunodo/localhost.json",
-                "--mnemonic",
-                "test test test test test test test test test test test junk",
-                # template hash is not relevant in host mode, so we can specify hash zero
-                "--templateHash",
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "--outputFile",
-                "/usr/share/sunodo/dapp.json",
-            ]
-
     validator:
         environment:
             CARTESI_FEATURE_HOST_MODE: true


### PR DESCRIPTION
Running: sunodo run --no-backend 
Yields a halted prompt. When I run in verbose mode: `sunodo run --no-backend --block-time 1 --verbose`
I am seeing this issue:

```
dapp_deployer-1             | /entrypoint.sh: 3: exec: create: not found
```