### PR TITLE
Use SDK 0.4

### DIFF
--- a/.changeset/curly-rats-yell.md
+++ b/.changeset/curly-rats-yell.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+move to sdk 0.4 (machine-emulator-sdk 0.17.1)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -31,6 +31,7 @@
         "execa": "^8.0",
         "fs-extra": "^11",
         "giget": "^1.2.3",
+        "lookpath": "^1.2.2",
         "open": "^10.1.0",
         "ora": "^8.0.1",
         "progress-stream": "^2.0",

--- a/apps/cli/src/commands/create.ts
+++ b/apps/cli/src/commands/create.ts
@@ -4,7 +4,7 @@ import type { TemplateProvider } from "giget";
 import { DownloadTemplateResult, downloadTemplate } from "giget";
 import ora from "ora";
 
-const DEFAULT_TEMPLATES_BRANCH = "sdk-0.3";
+export const DEFAULT_TEMPLATES_BRANCH = "sdk-0.4";
 
 export default class CreateCommand extends Command {
     static description = "Create application";

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -1,6 +1,7 @@
 import { Args, Command, Flags } from "@oclif/core";
 import { execa } from "execa";
 import fs from "fs-extra";
+import { lookpath } from "lookpath";
 import path from "path";
 
 export default class Shell extends Command {
@@ -31,7 +32,7 @@ export default class Shell extends Command {
         const ext2 = path.join(containerDir, path.basename(ext2Path));
         const ramSize = "128Mi";
         const driveLabel = "root";
-        const sdkImage = "sunodo/sdk:0.2.0"; // XXX: how to resolve sdk version?
+        const sdkImage = "sunodo/sdk:0.4.0"; // XXX: how to resolve sdk version?
         const args = [
             "run",
             "--interactive",
@@ -41,12 +42,18 @@ export default class Shell extends Command {
             sdkImage,
             "cartesi-machine",
             `--ram-length=${ramSize}`,
-            "--rollup",
+            "--append-bootargs=no4lvl",
             `--flash-drive=label:${driveLabel},filename:${ext2}`,
-            "-i",
         ];
+
         if (runAsRoot) {
-            args.push("--append-rom-bootargs='single=yes'");
+            args.push("--append-init=USER=root");
+        }
+
+        if (!(await lookpath("stty"))) {
+            args.push("-i");
+        } else {
+            args.push("-it");
         }
 
         await execa("docker", [...args, "--", "/bin/bash"], {

--- a/apps/cli/src/node/DockerfileDeploy.txt
+++ b/apps/cli/src/node/DockerfileDeploy.txt
@@ -1,4 +1,4 @@
-FROM cartesi/rollups-node:1.3.1
+FROM cartesi/rollups-node:1.4.0
 ENV CARTESI_SNAPSHOT_DIR=/usr/share/rollups-node/snapshot
 ENV CARTESI_HTTP_ADDRESS=0.0.0.0
 COPY --chown=cartesi:cartesi . ${CARTESI_SNAPSHOT_DIR}

--- a/apps/cli/src/node/docker-compose-anvil.yaml
+++ b/apps/cli/src/node/docker-compose-anvil.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     anvil:
         image: sunodo/devnet:1.4.0

--- a/apps/cli/src/node/docker-compose-database.yaml
+++ b/apps/cli/src/node/docker-compose-database.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     database:
         image: postgres:15-alpine

--- a/apps/cli/src/node/docker-compose-envfile.yaml
+++ b/apps/cli/src/node/docker-compose-envfile.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
     validator:
         env_file:

--- a/apps/cli/src/node/docker-compose-explorer.yaml
+++ b/apps/cli/src/node/docker-compose-explorer.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     database_creator:
         image: postgres:15-alpine

--- a/apps/cli/src/node/docker-compose-host.yaml
+++ b/apps/cli/src/node/docker-compose-host.yaml
@@ -3,6 +3,7 @@ services:
     validator:
         environment:
             CARTESI_FEATURE_HOST_MODE: true
+        command: ["cartesi-rollups-node"]
 
     traefik-config-generator:
         environment:

--- a/apps/cli/src/node/docker-compose-host.yaml
+++ b/apps/cli/src/node/docker-compose-host.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
     validator:
         environment:

--- a/apps/cli/src/node/docker-compose-prompt.yaml
+++ b/apps/cli/src/node/docker-compose-prompt.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     prompt:
         image: debian:bookworm-slim

--- a/apps/cli/src/node/docker-compose-proxy.yaml
+++ b/apps/cli/src/node/docker-compose-proxy.yaml
@@ -1,18 +1,16 @@
-version: "3.9"
-
 services:
     traefik-config-generator:
         image: debian:bookworm-slim
         command:
-        - /bin/bash
-        - -c
-        - |
-            for cfg_file in $${!TRAEFIK_CONFIG_*}
-            do
-                declare -n cfg_content=$$cfg_file
-                _cfg_file=$${cfg_file:15}
-                echo "$$cfg_content" > /etc/traefik/conf.d/$${_cfg_file,,}.yaml
-            done
+            - /bin/bash
+            - -c
+            - |
+                for cfg_file in $${!TRAEFIK_CONFIG_*}
+                do
+                    declare -n cfg_content=$$cfg_file
+                    _cfg_file=$${cfg_file:15}
+                    echo "$$cfg_content" > /etc/traefik/conf.d/$${_cfg_file,,}.yaml
+                done
         volumes:
             - traefik-conf:/etc/traefik/conf.d
 
@@ -34,7 +32,7 @@ services:
                 "--metrics.prometheus=true",
                 "--metrics.prometheus.addServicesLabels=true",
                 "--providers.file.directory=/etc/traefik/conf.d",
-                "--providers.file.watch=true"
+                "--providers.file.watch=true",
             ]
         ports:
             - ${SUNODO_LISTEN_PORT:-8080}:8088

--- a/apps/cli/src/node/docker-compose-snapshot-volume.yaml
+++ b/apps/cli/src/node/docker-compose-snapshot-volume.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     dapp_deployer:
         volumes:

--- a/apps/cli/src/node/docker-compose-validator.yaml
+++ b/apps/cli/src/node/docker-compose-validator.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
     validator:
         image: cartesi/rollups-node:1.4.0

--- a/apps/cli/src/node/docker-compose-validator.yaml
+++ b/apps/cli/src/node/docker-compose-validator.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
     validator:
-        image: cartesi/rollups-node:1.3.1
+        image: cartesi/rollups-node:1.4.0
         depends_on:
             dapp_deployer:
                 condition: service_completed_successfully

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       giget:
         specifier: ^1.2.3
         version: 1.2.3
+      lookpath:
+        specifier: ^1.2.2
+        version: 1.2.2
       open:
         specifier: ^10.1.0
         version: 10.1.0
@@ -17571,6 +17574,12 @@ packages:
       ansi-fragments: 0.2.1
       dayjs: 1.11.10
       yargs: 15.4.1
+
+  /lookpath@1.2.2:
+    resolution: {integrity: sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==}
+    engines: {npm: '>=6.13.4'}
+    hasBin: true
+    dev: false
 
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}


### PR DESCRIPTION
Make CLI use SDK 0.4.0 (machine-emulator-sdk 0.17.1)

Depends on: 

- sunodo: https://github.com/sunodo/sunodo-templates/pull/37 and published `sdk-0.4` branch.
- cartesi: final release of cartesi/rollups-node:1.4.0