### PR TITLE
New ERC-721 and ERC-1155 test contracts

### DIFF
--- a/.changeset/wicked-ladybugs-bake.md
+++ b/.changeset/wicked-ladybugs-bake.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/devnet": minor
+---
+
+new ERC-721 and ERC-1155 test contracts


### PR DESCRIPTION
This willl trigger a new release of the devnet image.

Notice here one drawback of the release process, which is subject of issue #406 
There is no change in code of the PR, only a changeset to trigger the CI process of rebuilding the docker image.

The build of the Docker image should be separate from the release of npm packages.
The dependency of the `devnet` npm package is to `"@sunodo/token": "workspace:*"`.
If pnpm release process was in place we could have a `devnet` published npm package linked to `@sunodo/token@0.6.0`, which is the last published version.

And then there would be a docker release process from the devnet published npm package.