### PR TITLE
Replace goerli with sepolia

### DIFF
--- a/.changeset/thin-worms-wonder.md
+++ b/.changeset/thin-worms-wonder.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+replace arbitrum-goerli and optimism-goerli with arbitrum-sepolia and optimism-sepolia

--- a/apps/cli/src/wallet.ts
+++ b/apps/cli/src/wallet.ts
@@ -17,11 +17,11 @@ import {
 import { mnemonicToAccount, privateKeyToAccount } from "viem/accounts";
 import {
     arbitrum,
-    arbitrumGoerli,
+    arbitrumSepolia,
     foundry,
     mainnet,
     optimism,
-    optimismGoerli,
+    optimismSepolia,
     sepolia,
 } from "viem/chains";
 
@@ -48,7 +48,7 @@ export const supportedChains = (options?: SupportedChainsOptions): Chain[] => {
         chains.push(foundry);
     }
     if (options.includeTestnets) {
-        chains.push(arbitrumGoerli, optimismGoerli, sepolia);
+        chains.push(arbitrumSepolia, optimismSepolia, sepolia);
     }
     if (options.includeMainnets) {
         chains.push(arbitrum, mainnet, optimism);


### PR DESCRIPTION
Wallet configuration used by `sunodo send` was using arbitrum-goerli and optimism-goerli instead of arbitrum-sepolia and optimism-sepolia