### PR TITLE
Quiet shell command

### DIFF
--- a/.changeset/beige-plums-yell.md
+++ b/.changeset/beige-plums-yell.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+quiet sunodo shell

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -36,6 +36,7 @@ export default class Shell extends Command {
             "run",
             "--interactive",
             "--tty",
+            "--quiet",
             "--volume",
             bind,
             sdkImage,

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -36,6 +36,7 @@ export default class Shell extends Command {
             "run",
             "--interactive",
             "--tty",
+            "--rm",
             "--quiet",
             "--volume",
             bind,


### PR DESCRIPTION
This PR will default the `sunodo shell` command to be quieter.

By default the underlying `docker run` command will print the download of all `sunodo/sdk` layers, which I think is necessary.

I opted not to add a `--verbose` option (like I did on other similar PRs), since it's not relevant to the functionality of `sunodo shell`.

This:

```shell
❯ sunodo shell
Running in interactive mode!

         .
        / \
      /    \
\---/---\  /----\
 \       X       \
  \----/  \---/---\
       \    / CARTESI
        \ /   MACHINE
         '

root@cartesi-machine:~# 

```

instead of this:

```shell
❯ sunodo shell
Unable to find image 'sunodo/sdk:0.2.0' locally
0.2.0: Pulling from sunodo/sdk
648e0aadf75a: Already exists 
2964fc34cbe6: Pull complete 
ae042b00ecc7: Pull complete 
26aaedd16546: Pull complete 
e5520a28c371: Pull complete 
894cfee3137f: Pull complete 
dda4cf2d2c70: Pull complete 
4f7f03a6fe95: Pull complete 
42dbeeaddcbf: Pull complete 
1685d3251fb1: Pull complete 
371c5ee4daa3: Pull complete 
5c90f86193d6: Pull complete 
6ec324d285ac: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:c1f50b6b87eb83ee3881030802134ce39349832ce3b2dc789dac2d657e4a83df
Status: Downloaded newer image for sunodo/sdk:0.2.0
Running in interactive mode!

         .
        / \
      /    \
\---/---\  /----\
 \       X       \
  \----/  \---/---\
       \    / CARTESI
        \ /   MACHINE
         '

root@cartesi-machine:~#
```