### PR TITLE
fix: check docker and docker compose in sunodo doctor

### DIFF
--- a/.changeset/ten-llamas-smile.md
+++ b/.changeset/ten-llamas-smile.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+fixed checking docker and docker compose in sunodo doctor


### PR DESCRIPTION
/close #412 

If the user doesn't have docker : 

![image](https://github.com/sunodo/sunodo/assets/51019382/5b30059f-9d0d-4475-8eac-272dfa875913)

If the user doesn't have docker compose : 

![image](https://github.com/sunodo/sunodo/assets/51019382/79ac5b23-c850-45f5-be63-657fc360c9d1)

Minimum docker version error : 

![image](https://github.com/sunodo/sunodo/assets/51019382/8f075772-3bbe-4d11-b3ab-074ef8945dc9)


Minimum docker compose version error : 

![image](https://github.com/sunodo/sunodo/assets/51019382/b9cb6e12-fd5a-43da-81ee-d27906ab4503)
