### PR TITLE
feat(cli): use crane to build rootfs tarball

### DIFF
--- a/.changeset/tiny-cats-tickle.md
+++ b/.changeset/tiny-cats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+use crane to build rootfs tarball

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -32,7 +32,7 @@ export default class Shell extends Command {
         const ext2 = path.join(containerDir, path.basename(ext2Path));
         const ramSize = "128Mi";
         const driveLabel = "root";
-        const sdkImage = "sunodo/sdk:0.4.0"; // XXX: how to resolve sdk version?
+        const sdkImage = "sunodo/sdk:0.4.1"; // XXX: how to resolve sdk version?
         const args = [
             "run",
             "--interactive",


### PR DESCRIPTION
This will use the crane utility available inside the latest sunodo/sdk.

Depends on: #466 #459 