### PR TITLE
Add shellpath arg to sunodo shell

### DIFF
--- a/.changeset/rude-seas-protect.md
+++ b/.changeset/rude-seas-protect.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": minor
+---
+
+add shellpath arg to sunodo shell

--- a/apps/cli/src/commands/shell.ts
+++ b/apps/cli/src/commands/shell.ts
@@ -14,6 +14,11 @@ export default class Shell extends Command {
             description: "image ID|name",
             required: false,
         }),
+        shellPath: Args.string({
+            description: "path to the shell executable",
+            required: false,
+            default: "/bin/bash",
+        }),
     };
 
     static flags = {
@@ -26,6 +31,7 @@ export default class Shell extends Command {
     private async startShell(
         ext2Path: string,
         runAsRoot: boolean,
+        shellPath: string,
     ): Promise<void> {
         const containerDir = "/mnt";
         const bind = `${path.resolve(path.dirname(ext2Path))}:${containerDir}`;
@@ -56,13 +62,13 @@ export default class Shell extends Command {
             args.push("-it");
         }
 
-        await execa("docker", [...args, "--", "/bin/bash"], {
+        await execa("docker", [...args, "--", shellPath], {
             stdio: "inherit",
         });
     }
 
     public async run(): Promise<void> {
-        const { flags } = await this.parse(Shell);
+        const { args, flags } = await this.parse(Shell);
 
         // use pre-existing image or build dapp image
         const ext2Path = path.join(".sunodo", "image.ext2");
@@ -71,6 +77,6 @@ export default class Shell extends Command {
         }
 
         // execute the machine and save snapshot
-        await this.startShell(ext2Path, flags["run-as-root"]);
+        await this.startShell(ext2Path, flags["run-as-root"], args.shellPath);
     }
 }


### PR DESCRIPTION
/close #469 

default shell is `/bin/bash`: 

![image](https://github.com/sunodo/sunodo/assets/51019382/8b3f37c7-4365-4940-a02f-b8293306cfc6)


could define the specific shell :
```sh
sunodo shell shellpath /bin/sh
```

![image](https://github.com/sunodo/sunodo/assets/51019382/d27411dc-f59b-4764-b54d-84782b6a0394)
