### PR TITLE
Add anvil to sdk

### DIFF
--- a/.changeset/light-dingos-ring.md
+++ b/.changeset/light-dingos-ring.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/sdk": minor
+---
+
+add anvil

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -62,8 +62,10 @@ apt-get update
 apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    jq \
     libarchive-tools \
     locales \
+    xxd \
     xz-utils
 rm -rf /var/lib/apt/lists/*
 
@@ -86,6 +88,16 @@ EOF
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
+
+# download anvil pre-compiled binaries
+ARG ANVIL_VERSION=f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9
+RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${ANVIL_VERSION}/foundry_nightly_linux_$(dpkg --print-architecture).tar.gz | \
+    tar -zx -C /usr/local/bin
+
+# healthcheck script using net_listening JSON-RPC method
+COPY eth_isready /usr/local/bin
+COPY eth_dump /usr/local/bin
+COPY eth_load /usr/local/bin
 
 COPY entrypoint.sh /usr/local/bin/
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/

--- a/packages/sdk/eth_dump
+++ b/packages/sdk/eth_dump
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# dump the state from the JSON-RPC server, convert from the hex anvil returns to text, which is a JSON string
+curl \
+    -sL \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    --data '{"id":1,"jsonrpc":"2.0","method":"anvil_dumpState","params":[]}' "${RPC_URL:-http://127.0.0.1:8545}" | \
+jq -r .result| \
+cut -c 3- | \
+xxd -r -p

--- a/packages/sdk/eth_isready
+++ b/packages/sdk/eth_isready
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# https://ethereum.org/en/developers/docs/apis/json-rpc/#net_listening
+curl -X POST -s -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":"1","method":"net_listening","params":[]}' ${RPC_URL:-http://127.0.0.1:8545} | jq '.result'

--- a/packages/sdk/eth_load
+++ b/packages/sdk/eth_load
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -e
+RPC_URL="${RPC_URL:-http://127.0.0.1:8545}"
+
+# use a large column value so we have everything on one line, even though man says 256 is the maximum
+STATE=$(xxd -ps -c 1000000000)
+
+# build the JSON-RPC request, and write to a file because it's too long for the curl call
+DATA="{\"id\":2,\"jsonrpc\":\"2.0\",\"method\":\"anvil_loadState\",\"params\":[\"0x$STATE\"]}"
+TMPFILE=$(mktemp)
+echo "$DATA" > "$TMPFILE"
+
+echo "Loading state into ${RPC}"
+curl -sL -H 'Content-Type: application/json' -d @"$TMPFILE" "$RPC_URL" | jq -r .result


### PR DESCRIPTION
This adds anvil to the sdk image.

A future PR will delete the `anvil` image once it's no longer used (by the devnet).
