### PR TITLE
devnet publishing

### DIFF
--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -12,6 +12,8 @@ on:
                 required: true
             NPM_TOKEN:
                 required: true
+            TURBO_TOKEN:
+                required: true
     pull_request:
         paths:
             - .github/workflows/devnet.yaml
@@ -26,6 +28,9 @@ permissions:
 jobs:
     build:
         runs-on: ubuntu-latest
+        env:
+            TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+            TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/devnet.yaml
+++ b/.github/workflows/devnet.yaml
@@ -1,10 +1,16 @@
 name: devnet
 on:
     workflow_call:
+        inputs:
+            release:
+                type: boolean
+                required: false
         secrets:
             DOCKERHUB_USERNAME:
                 required: true
             DOCKERHUB_TOKEN:
+                required: true
+            NPM_TOKEN:
                 required: true
     pull_request:
         paths:
@@ -39,6 +45,13 @@ jobs:
 
             - name: Build
               run: pnpm build --filter @sunodo/devnet
+
+            - name: Publish
+              if: ${{ inputs.release }}
+              run: pnpm publish --access public
+              working-directory: packages/devnet
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Get package tag/version
               id: package-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,8 @@ jobs:
         if: ${{ needs.release.outputs.published == 'true' && contains(fromJSON(needs.packages_to_build.outputs.packages), '@sunodo/devnet') }}
         uses: ./.github/workflows/devnet.yaml
         secrets: inherit
+        with:
+            release: true
 
     build_contracts:
         name: Build contracts

--- a/packages/devnet/package.json
+++ b/packages/devnet/package.json
@@ -33,6 +33,7 @@
         "@openzeppelin/contracts": "5.0.2"
     },
     "files": [
+        "build",
         "deployments/*/*.json",
         "deployments/*/.chainid",
         "dist/src",


### PR DESCRIPTION
This PR configures the CI to publish a @sunodo/devnet npm package.
The package will be used by the sdk in a future PR to install it inside the sdk Docker image.
The Docker image of the devnet itself will be deprecated after that.