### PR TITLE
devnet in SDK

### DIFF
--- a/.changeset/many-zoos-move.md
+++ b/.changeset/many-zoos-move.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/sdk": minor
+---
+
+add devnet files

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -100,6 +100,7 @@ RUN curl -sSL https://github.com/foundry-rs/foundry/releases/download/nightly-${
     tar -zx -C /usr/local/bin
 
 # healthcheck script using net_listening JSON-RPC method
+COPY devnet /usr/local/bin
 COPY eth_isready /usr/local/bin
 COPY eth_dump /usr/local/bin
 COPY eth_load /usr/local/bin

--- a/packages/sdk/Dockerfile
+++ b/packages/sdk/Dockerfile
@@ -46,6 +46,11 @@ curl -sSL https://github.com/google/go-containerregistry/releases/download/v${CR
     tar -zx -C /usr/local/bin
 EOF
 
+# devnet files
+FROM node:slim as devnet
+ARG DEVNET_VERSION
+RUN npm install -g @sunodo/devnet@${DEVNET_VERSION}
+
 # sdk image
 FROM $SERVER_MANAGER_REGISTRY/$SERVER_MANAGER_ORG/server-manager:$SERVER_MANAGER_VERSION
 ARG SERVER_MANAGER_REGISTRY
@@ -102,6 +107,8 @@ COPY eth_load /usr/local/bin
 COPY entrypoint.sh /usr/local/bin/
 COPY --from=su-exec /usr/local/src/su-exec /usr/local/bin/
 COPY --from=crane /usr/local/bin/crane /usr/local/bin/
+COPY --from=devnet /usr/local/lib/node_modules/@sunodo/devnet/export/abi/localhost.json /usr/share/cartesi/
+COPY --from=devnet /usr/local/lib/node_modules/@sunodo/devnet/build/anvil_state.json /usr/share/cartesi/
 RUN mkdir -p /tmp/.sunodo && chmod 1777 /tmp/.sunodo
 
 ADD --chmod=644 \

--- a/packages/sdk/devnet
+++ b/packages/sdk/devnet
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+jq -r '.contracts | to_entries | .[] | "\(.value.address) \(.key)"' < /usr/share/cartesi/localhost.json
+exec anvil --load-state /usr/share/cartesi/anvil_state.json "$@"

--- a/packages/sdk/docker-bake.hcl
+++ b/packages/sdk/docker-bake.hcl
@@ -9,6 +9,7 @@ target "default" {
     SERVER_MANAGER_ORG            = "cartesi"
     SERVER_MANAGER_VERSION        = "0.9.1"
     CARTESI_IMAGE_KERNEL_VERSION  = "0.19.1"
+    DEVNET_VERSION                = "1.6.0"
     LINUX_KERNEL_VERSION          = "6.5.9-ctsi-1-v0.19.1"
   }
 }


### PR DESCRIPTION
This PR adds to the SDK files from the @sunodo/devnet npm package that are necessary to boot an anvil with the Cartesi and test contracts.

Only two files are necessary:
1. `anvil_state.json`: state file used to load anvil with deployed contracts
2. `localhost.json`: information about deployed contracts (ABIs and addresses)

The `localhost.json` is actually used only to print-out information during anvil startup.
I included a `devnet` shell script that was previously the `entrypoint.sh` file of the `sunodo/devnet` Docker image (which will be deprecated).
The command to start the devnet from the sdk image is a little unhandy:

```shell
docker run -e ANVIL_IP_ADDR=0.0.0.0 -p 8545:8545  --entrypoint /usr/local/bin/devnet sunodo/sdk:devel anvil --load-state /usr/share/cartesi/anvil_state.json
```

Maybe we should provide an easier way to do that.
I often use the devnet docker image as a very fast and convenient way to start an anvil with Cartesi by simply using the command:

```shell
docker run -e ANVIL_IP_ADDR=0.0.0.0 -p 8545:8545 sunodo/devnet:1.5.0
```

I published the `@sunodo/devnet@1.5.0` manually to test this. Unfortunately the 1.5.0 had a bug in the publishing that it was not including the `anvil_state.json` file in the package.
That bug is fixed in PR #479 . And there is a commit in this PR that must be deleted before merging.