### PR TITLE
Fix ext2 drive size specification

### DIFF
--- a/.changeset/slimy-impalas-wave.md
+++ b/.changeset/slimy-impalas-wave.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/cli": patch
+---
+
+fix ext2 drive size specification

--- a/apps/cli/src/commands/build.ts
+++ b/apps/cli/src/commands/build.ts
@@ -217,16 +217,20 @@ Update your application Dockerfile using one of the templates at https://github.
     }
 
     // returns the command to create ext2 from a rootfs
-    private static createExt2Command(): string[] {
+    private static createExt2Command(extraBytes: number): string[] {
+        const blockSize = 4096;
+        const extraBlocks = Math.ceil(extraBytes / blockSize);
+        const extraSize = `+${extraBlocks}`;
+
         return [
             "xgenext2fs",
             "--tarball",
             "/tmp/input",
             "--block-size",
-            "4096",
+            blockSize.toString(),
             "--faketime",
             "-r",
-            "+1",
+            extraSize,
             "/tmp/output",
         ];
     }
@@ -292,7 +296,9 @@ Update your application Dockerfile using one of the templates at https://github.
             // create ext2
             await this.sdkRun(
                 sdkImage,
-                BuildApplication.createExt2Command(),
+                BuildApplication.createExt2Command(
+                    bytes.parse(imageInfo.dataSize),
+                ),
                 SUNODO_DEFAULT_RETAR_TAR_PATH,
                 SUNODO_DEFAULT_EXT2_PATH,
             );


### PR DESCRIPTION
`sunodo build` of 0.13 was not taking into consideration increment of ext2 drive specified in the Dockerfile `io.cartesi.rollups.data_size` label