### PR TITLE
Fix mixed addresses

### DIFF
--- a/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
+++ b/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
@@ -79,7 +79,7 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
         args: [authorityOwner, applicationOwner!, templateHash, salt],
         query: { enabled },
     });
-    const [authorityAddress, historyAddress, applicationAddress] = data || [];
+    const [applicationAddress, authorityAddress, historyAddress] = data || [];
 
     // simulate deploy transaction
     const simulate = useSimulateSelfHostedApplicationFactoryDeployContracts({


### PR DESCRIPTION
The deploy web app is mixing the addresses when presenting the configuration
