### PR TITLE
Documentation transition to Cartesi CLI

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -19,6 +19,10 @@ const guideSidebar = (): DefaultTheme.SidebarItem[] => {
                     text: "Quick start",
                     link: "/guide/introduction/quick-start",
                 },
+                {
+                    text: "Migrating a Sunodo project",
+                    link: "/guide/introduction/migrating",
+                },
             ],
         },
         {

--- a/apps/docs/guide/building/building-application.md
+++ b/apps/docs/guide/building/building-application.md
@@ -1,9 +1,13 @@
 # Building application
 
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
 To build an existing application simply use the command below:
 
 ```shell
-sunodo build
+cartesi build
 ```
 
 The build process use [Docker](https://www.docker.com/), so you need to have it installed and running, as described in the [system requirements](../introduction/installing#system-requirements) section.

--- a/apps/docs/guide/building/customizing.md
+++ b/apps/docs/guide/building/customizing.md
@@ -1,14 +1,18 @@
 # Customizing the build
 
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
 The build process of a Cartesi application is guided by a `Dockerfile` which is part of the application code, and can be customized as any `Dockerfile`, as long as the final stage of a multi-stage build produces a `linux/riscv64` docker image.
 
-The default multi-stage build `target` is the last one, but can be customized with the `--target` option of the `sunodo build` command.
+The default multi-stage build `target` is the last one, but can be customized with the `--target` option of the `cartesi build` command.
 
-The `sunodo build` command calls `docker buildx build` under the hood, and there are many docker options that are not exposed by the sunodo CLI. In case the user needs advanced docker options he can build the `linux/riscv64` Docker image himself, and call `sunodo build` with the `--from-image` option to specify the name or sha of the image he built manually.
+The `cartesi build` command calls `docker buildx build` under the hood, and there are many docker options that are not exposed by the cartesi CLI. In case the user needs advanced docker options he can build the `linux/riscv64` Docker image himself, and call `cartesi build` with the `--from-image` option to specify the name or sha of the image he built manually.
 
 ## Memory
 
-The Cartesi machine created by Sunodo uses 128Mb of RAM by default. This can be customized by setting the `io.cartesi.rollups.ram_size` Docker label in the final image, like the one below:
+The Cartesi machine created by the Cartesi CLI uses 128Mb of RAM by default. This can be customized by setting the `io.cartesi.rollups.ram_size` Docker label in the final image, like the one below:
 
 ```dockerfile
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/apps/docs/guide/creating/available-templates.md
+++ b/apps/docs/guide/creating/available-templates.md
@@ -1,18 +1,22 @@
 # Available templates
 
-Sunodo provides basic templates for different programming languages and runtimes. These templates are designed to be a starting point for your application, and can be customized to fit your needs.
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
 
-The official templates below are hosted at the [templates public repository](https://github.com/sunodo/sunodo-templates).
+Cartesi provides basic templates for different programming languages and runtimes. These templates are designed to be a starting point for your application, and can be customized to fit your needs.
+
+The official templates below are hosted at the [templates public repository](https://github.com/cartesi/application-templates).
 
 -   `cpp`: C++ template
 -   `cpp-low-level`: C++ template using the low level API, instead of the HTTP server
 -   `go`: Go lang template
--   [`javascript`](https://github.com/sunodo/sunodo-templates/blob/main/javascript/README.md): NodeJS 20 template
+-   [`javascript`](https://github.com/cartesi/application-templates/blob/main/javascript/README.md): NodeJS 20 template
 -   `lua`: Lua 5.4 template
--   [`python`](https://github.com/sunodo/sunodo-templates/blob/main/python/README.md): python 3 template
+-   [`python`](https://github.com/cartesi/application-templates/blob/main/python/README.md): python 3 template
 -   `ruby`: ruby template
 -   `rust`: rust template
--   [`typescript`](https://github.com/sunodo/sunodo-templates/blob/main/typescript/README.md): TypeScript template
+-   [`typescript`](https://github.com/cartesi/application-templates/blob/main/typescript/README.md): TypeScript template
 
 ## Community templates
 

--- a/apps/docs/guide/creating/creating-application.md
+++ b/apps/docs/guide/creating/creating-application.md
@@ -1,11 +1,15 @@
 # Creating application
 
-One of `sunodo`'s goal is to be the easiest way to create new [Cartesi](https://cartesi.io) applications from scratch.
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
+One of `cartesi`'s goal is to be the easiest way to create new [Cartesi](https://cartesi.io) applications from scratch.
 
 To create a new application from a basic javascript template, run:
 
 ```shell
-$ sunodo create my-app --template javascript
+$ cartesi create my-app --template javascript
 ✔ Application created at my-app
 ```
 

--- a/apps/docs/guide/deploying/deploying-application.md
+++ b/apps/docs/guide/deploying/deploying-application.md
@@ -1,17 +1,13 @@
 # Deploying application
 
-::: warning
-This is still under development and will be available in a future release.
-:::
-
 The deployment of a Cartesi rollups application has two main components: a Cartesi genesis machine, and a smart contract deployed to the [base layer of choice](./supported-networks.md).
 
 ## Cartesi machine
 
-The Cartesi genesis machine is produced by the [sunodo build](../building/building-application.md) command, and must be installed alongside a Cartesi [rollups node](https://github.com/cartesi/rollups-node). The machine contains a hash that represents the initial state of the application (including the application itself). The hash can be obtained using the `sunodo hash` command:
+The Cartesi genesis machine is produced by the [cartesi build](../building/building-application.md) command, and must be installed alongside a Cartesi [rollups node](https://github.com/cartesi/rollups-node). The machine contains a hash that represents the initial state of the application (including the application itself). The hash can be obtained using the `cartesi hash` command:
 
 ```shell
-$ sunodo hash
+$ cartesi hash
 ? Cartesi machine templateHash 0xc87999b8a93609268b10de25f2e49d35f80fad92813310edc585ed644a9805d3
 ```
 

--- a/apps/docs/guide/deploying/self-hosted.md
+++ b/apps/docs/guide/deploying/self-hosted.md
@@ -9,12 +9,12 @@ This method of deployment allows the developer to run his own infrastructure to 
 
 ## Deploying
 
-The self-hosted deployment process can be initiated by the `sunodo deploy --hosting self-hosted` command.
+The self-hosted deployment process can be initiated by the `cartesi deploy --hosting self-hosted --webapp https://sunodo.io/deploy` command.
 
 That command will show the Cartesi machine hash and build a Docker image containing the Cartesi rollups node and the Cartesi machine:
 
 ```shell
-$ sunodo deploy --hosting self-hosted
+$ cartesi deploy --hosting self-hosted --webapp https://sunodo.io/deploy
 ? Cartesi machine templateHash 0xc87999b8a93609268b10de25f2e49d35f80fad92813310edc585ed644a9805d3
 ? Application node Docker image sha256:5c355a9bddc92aa08987f395a257a0b32a51552c969eb161386e46f9380ea2ac
 ```
@@ -166,7 +166,7 @@ The developer is free to use any managed container solution, like Kubernetes. Th
     Tag the image produced in the beginning of the process and push it to the Fly.io registry:
 
     ::: warning
-    If you are using macOS with Apple Silicon and are deploying to Fly.io you may need to produce a Docker image for the architecture used by Fly.io, which is `linux/amd64`. You can use the following command to build the image: `sunodo deploy build --platform linux/amd64`
+    If you are using macOS with Apple Silicon and are deploying to Fly.io you may need to produce a Docker image for the architecture used by Fly.io, which is `linux/amd64`. You can use the following command to build the image: `cartesi deploy build --platform linux/amd64`
     :::
 
     ```shell

--- a/apps/docs/guide/introduction/installing.md
+++ b/apps/docs/guide/introduction/installing.md
@@ -1,6 +1,10 @@
 # Installing
 
-The `sunodo` CLI tool can be installed on macOS and Linux, and on Windows using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
+The `cartesi` CLI tool can be installed on macOS and Linux, and on Windows using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 
 ## System requirements
 
@@ -22,21 +26,21 @@ docker run --privileged --rm tonistiigi/binfmt:riscv
 MacOS [Homebrew](https://brew.sh) users can install sunodo with:
 
 ```shell
-brew install sunodo/tap/sunodo
+brew install cartesi/tap/cartesi
 ```
 
-Users who don't use [Homebrew](https://brew.sh) should install [Node.js](https://nodejs.org/) and then install `sunodo` with:
+Users who don't use [Homebrew](https://brew.sh) should install [Node.js](https://nodejs.org/) and then install `cartesi` with:
 
 ```shell
-npm install -g @sunodo/cli
+npm install -g @cartesi/cli
 ```
 
 ## Linux
 
-Linux users can either also use [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux), or install [Node.js](https://nodejs.org/) and then install `sunodo` with:
+Linux users can either also use [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux), or install [Node.js](https://nodejs.org/) and then install `cartesi` with:
 
 ```shell
-npm install -g @sunodo/cli
+npm install -g @cartesi/cli
 ```
 
 ::: info

--- a/apps/docs/guide/introduction/migrating.md
+++ b/apps/docs/guide/introduction/migrating.md
@@ -1,0 +1,18 @@
+# Migrating a Sunodo project
+
+This section describe the steps to take to migrate a Sunodo application to a Cartesi CLI application.
+
+1. uninstall Sunodo CLI;
+
+    - `brew uninstall sunodo` if installed using brew
+    - `npm uninstall -g sunodo` if installed using npm
+
+2. [install Cartesi CLI](/guide/introduction/installing.md);
+
+3. review your Dockerfile, possibly replacing with a fresh one from [https://github.com/cartesi/application-templates](https://github.com/cartesi/application-templates);
+
+4. rename the `.sunodo` directory to `.cartesi`;
+
+5. change the `.gitignore` file to ignore the `.cartesi` directory instead of the `.sunodo` directory;
+
+6. rename the `.sunodo.env` file to `.cartesi.env` if you have one.

--- a/apps/docs/guide/introduction/quick-start.md
+++ b/apps/docs/guide/introduction/quick-start.md
@@ -1,12 +1,16 @@
 # Quick start
 
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
 The following commands will get you started with a javascript project, build a Cartesi machine and run a local node for the application:
 
 ```shell
-sunodo create my-app --template javascript
+cartesi create my-app --template javascript
 cd my-app
-sunodo build
-sunodo run
+cartesi build
+cartesi run
 ```
 
 This will run an [anvil](https://book.getfoundry.sh/reference/anvil/) node as a local blockchain, and the GraphQL service and Inspect Service.

--- a/apps/docs/guide/introduction/what-is-sunodo.md
+++ b/apps/docs/guide/introduction/what-is-sunodo.md
@@ -1,14 +1,9 @@
 # What is Sunodo?
 
-Sunodo is a [Cartesi](https://cartesi.io) Rollups as a Service platform and a set of tools to improve the development workflow of Cartesi applications.
+Sunodo is a [Cartesi](https://cartesi.io) Rollups as a Service platform that facilitates the deployment of Cartesi applications.
 
-The main tool is the `sunodo` command line interface (CLI) that can be used to:
-
--   create applications from templates;
--   build applications from source to a Cartesi machine;
--   run applications in a local development environment;
--   test applications running inside a Cartesi machine;
--   deploy applications to a public or private network;
--   monitor applications already running.
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
 
 All code is available under a permissive license at [GitHub](https://github.com/sunodo/sunodo/). Contributions are welcome.

--- a/apps/docs/guide/running/running-application.md
+++ b/apps/docs/guide/running/running-application.md
@@ -1,6 +1,10 @@
 # Running application
 
-The `sunodo run` command will execute a Cartesi node for the application previously built with `sunodo build`.
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
+The `cartesi run` command will execute a Cartesi node for the application previously built with `cartesi build`.
 
 ## Verbosity
 
@@ -8,7 +12,7 @@ By default the node works on non-verbose mode, and only outputs logs coming from
 
 ## Blockchain configuration
 
-Sunodo runs a local private chain powered by [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil) at port `8545`. All contracts of the Cartesi Rollups framework are already deployed, and theirs addresses can be inspected using `sunodo address-book`.
+Cartesi CLI runs a local private chain powered by [anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil) at port `8545`. All contracts of the Cartesi Rollups framework are already deployed, and theirs addresses can be inspected using `cartesi address-book`.
 
 The private chain by default has a block time of 5 seconds, controlled by `--block-time <seconds>`, and runs on auto-mine mode.
 
@@ -18,14 +22,14 @@ By default the node closes an epoch once a day, but this can be controlled by th
 
 ## Rollups Node configuration
 
-You can create a `.sunodo.env` file in the root of your project to configure the node.
+You can create a `.cartesi.env` file in the root of your project to configure the node.
 
 All Rollups Node services can be configured using environment variables.
 
 For ex., in case you want to change the default deadline for advancing the state for the rollups-advance-runner service.
 
 ```shell
-cat .sunodo.env
+cat .cartesi.env
 SM_DEADLINE_ADVANCE_STATE=360000
 ```
 
@@ -33,7 +37,7 @@ Check the configuration options for each service in the [Rollups Node documentat
 
 ## No-backend mode
 
-Sunodo `run` also supports running a node without the user application backend packaged as a Cartesi machine. In this case the user application can be executed on the host, without the concern of being compiled to RISC-V.
+Cartesi `run` also supports running a node without the user application backend packaged as a Cartesi machine. In this case the user application can be executed on the host, without the concern of being compiled to RISC-V.
 
 This is a useful development workflow help, but there are some caveats the user must be aware:
 

--- a/apps/docs/guide/running/sending-inputs.md
+++ b/apps/docs/guide/running/sending-inputs.md
@@ -1,9 +1,13 @@
 # Sending inputs
 
+:::warning
+The Sunodo CLI is deprecated in favor of the new Cartesi CLI tool. Please refer to the [Cartesi documentation](https://docs.cartesi.io) for the most up-to-date information. If you have a Sunodo application and need to migrate to a Cartesi CLI application refer to the [migration guide](/guide/introduction/migrating).
+:::
+
 Applications receive inputs by sending transactions with the input payload to the `InputBox` smart contracts of the Cartesi rollups framework. To facilitate this process, we provide a CLI command to send inputs to a running application. The command below will guide you through an interactive process:
 
 ```shell
-sunodo send
+cartesi send
 ```
 
 To be more specific, there are 5 types of inputs you can send using a sub-command: `dapp-address`, `erc20`, `erc721`, `ether`, `generic`. These are detailed below:
@@ -13,7 +17,7 @@ To be more specific, there are 5 types of inputs you can send using a sub-comman
 This input is useful for applications that need to know its own address. The input payload is simply the address of the application and the sender is the `DAppAddressRelay` smart contract.
 
 ```shell
-sunodo send dapp-address
+cartesi send dapp-address
 ```
 
 ## ERC-20 Deposit
@@ -21,7 +25,7 @@ sunodo send dapp-address
 This input deposits ERC-20 tokens to the application. Refer to the `ERC20Portal` documentation to understand the input payload format and how to decode it.
 
 ```shell
-sunodo send erc20
+cartesi send erc20
 ```
 
 ## ERC-721 Deposit
@@ -29,7 +33,7 @@ sunodo send erc20
 This input deposits ERC-721 tokens (NFT) to the application. Refer to the `ERC721Portal` documentation to understand the input payload format and how to decode it.
 
 ```shell
-sunodo send erc721
+cartesi send erc721
 ```
 
 ## Ether Deposit
@@ -37,7 +41,7 @@ sunodo send erc721
 This input deposits Ether (native token) to the application. Refer to the `EtherPortal` documentation to understand the input payload format and how to decode it.
 
 ```shell
-sunodo send ether
+cartesi send ether
 ```
 
 ## Generic Input
@@ -45,7 +49,7 @@ sunodo send ether
 The input types above are specialized inputs with a pre-defined payload format and a trusted sender (a smart contract), but they all send inputs to the `InputBox`. The generic input allows you to send inputs with any payload format.
 
 ```shell
-sunodo send generic
+cartesi send generic
 ```
 
 The encoding of the payload, from what you specify in the CLI to the raw bytes the `InputBox` expects, can be specified with the `--input-encoding` option. We currently support the following encodings:


### PR DESCRIPTION
Change the doc website to refer to Cartesi CLI.
Sections about installing, creating, building, running are still there, with a deprecation warning. May be removed in the future.

Information about deploy still under Sunodo.
