### PR TITLE
Add withdrawal output builder factory option to deploy page

### DIFF
--- a/.changeset/withdrawal-output-builder.md
+++ b/.changeset/withdrawal-output-builder.md
@@ -1,0 +1,5 @@
+---
+"@sunodo/web": minor
+---
+
+Add a withdrawal output builder option to the deploy page. Besides pasting the address of an existing `IWithdrawalOutputBuilder` implementation, users can now deploy a USD withdrawal output builder for an ERC-20 token via the `UsdWithdrawalOutputBuilderFactory` (deployed on supported testnets), which reuses an already-deployed builder for the same token when one exists.

--- a/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
+++ b/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
@@ -96,6 +96,21 @@ const USD_BUILDER_SALT = zeroHash;
 
 const hasCode = (code?: string) => !!code && code !== "0x";
 
+const MAX_UINT64 = (1n << 64n) - 1n;
+
+// Parse a uint64 that may be entered as a decimal or a hexadecimal (0x-prefixed)
+// string. Returns null when the value is empty or out of the uint64 range.
+const parseUint64 = (value: string): bigint | null => {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+        const parsed = BigInt(trimmed);
+        return parsed >= 0n && parsed <= MAX_UINT64 ? parsed : null;
+    } catch {
+        return null;
+    }
+};
+
 type WithdrawalOutputBuilderProps = {
     disabled: boolean;
     // input props for the manual-address field (an already-deployed builder)
@@ -151,7 +166,10 @@ const WithdrawalOutputBuilder: FC<WithdrawalOutputBuilderProps> = ({
     });
     const builderExists = hasCode(builderCode.data);
 
-    // simulate + execute the factory deployment (only when not already deployed)
+    // simulate + execute the factory deployment. Only enable the simulation once we
+    // have confirmed the builder is NOT already deployed: simulating (or deploying) an
+    // existing builder would revert with a CREATE2 collision. When it already exists we
+    // simply reuse it, so no deployment — and no error — is needed.
     const simulate =
         useSimulateUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder(
             {
@@ -164,6 +182,7 @@ const WithdrawalOutputBuilder: FC<WithdrawalOutputBuilderProps> = ({
                         !!tokenAddress &&
                         factoryAvailable &&
                         !!builderAddress &&
+                        builderCode.isSuccess &&
                         !builderExists,
                 },
             },
@@ -272,32 +291,6 @@ const WithdrawalOutputBuilder: FC<WithdrawalOutputBuilderProps> = ({
                                 size="md"
                                 ff="mono"
                             />
-                            {simulate.isError && (
-                                <ScrollArea>
-                                    <Alert
-                                        title={simulate.error?.name}
-                                        variant="light"
-                                        color="red"
-                                        icon={<IconExclamationCircle />}
-                                        ff="mono"
-                                    >
-                                        {simulate.error?.message}
-                                    </Alert>
-                                </ScrollArea>
-                            )}
-                            {execute.isError && (
-                                <ScrollArea>
-                                    <Alert
-                                        title={execute.error?.name}
-                                        variant="light"
-                                        color="red"
-                                        icon={<IconExclamationCircle />}
-                                        ff="mono"
-                                    >
-                                        {execute.error?.message}
-                                    </Alert>
-                                </ScrollArea>
-                            )}
                             {builderExists ? (
                                 <Alert
                                     variant="light"
@@ -308,29 +301,58 @@ const WithdrawalOutputBuilder: FC<WithdrawalOutputBuilderProps> = ({
                                     application's withdrawals.
                                 </Alert>
                             ) : (
-                                <Group>
-                                    <Button
-                                        variant="light"
-                                        disabled={
-                                            !simulate.data?.request || disabled
-                                        }
-                                        loading={
-                                            simulate.isLoading ||
-                                            execute.isPending ||
-                                            (execute.isSuccess &&
-                                                receipt.isLoading)
-                                        }
-                                        onClick={() => {
-                                            if (simulate.data) {
-                                                execute.writeContract(
-                                                    simulate.data.request,
-                                                );
+                                <>
+                                    {simulate.isError && (
+                                        <ScrollArea>
+                                            <Alert
+                                                title={simulate.error?.name}
+                                                variant="light"
+                                                color="red"
+                                                icon={<IconExclamationCircle />}
+                                                ff="mono"
+                                            >
+                                                {simulate.error?.message}
+                                            </Alert>
+                                        </ScrollArea>
+                                    )}
+                                    {execute.isError && (
+                                        <ScrollArea>
+                                            <Alert
+                                                title={execute.error?.name}
+                                                variant="light"
+                                                color="red"
+                                                icon={<IconExclamationCircle />}
+                                                ff="mono"
+                                            >
+                                                {execute.error?.message}
+                                            </Alert>
+                                        </ScrollArea>
+                                    )}
+                                    <Group>
+                                        <Button
+                                            variant="light"
+                                            disabled={
+                                                !simulate.data?.request ||
+                                                disabled
                                             }
-                                        }}
-                                    >
-                                        Deploy builder
-                                    </Button>
-                                </Group>
+                                            loading={
+                                                simulate.isLoading ||
+                                                execute.isPending ||
+                                                (execute.isSuccess &&
+                                                    receipt.isLoading)
+                                            }
+                                            onClick={() => {
+                                                if (simulate.data) {
+                                                    execute.writeContract(
+                                                        simulate.data.request,
+                                                    );
+                                                }
+                                            }}
+                                        >
+                                            Deploy builder
+                                        </Button>
+                                    </Group>
+                                </>
                             )}
                         </>
                     )}
@@ -358,7 +380,7 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
             withdrawalOutputBuilder: "",
             log2LeavesPerAccount: 0,
             log2MaxNumOfAccounts: 0,
-            accountsDriveStartIndex: 0,
+            accountsDriveStartIndex: "0",
             salt: generatePrivateKey(),
         },
         validate: {
@@ -375,6 +397,8 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
                 !value || isAddress(value) ? null : "Invalid address",
             withdrawalOutputBuilder: (value) =>
                 !value || isAddress(value) ? null : "Invalid address",
+            accountsDriveStartIndex: (value) =>
+                !value || parseUint64(value) !== null ? null : "Invalid value",
         },
         validateInputOnChange: true,
         transformValues: (values) => ({
@@ -395,7 +419,8 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
                         : zeroAddress,
                 log2LeavesPerAccount: values.log2LeavesPerAccount,
                 log2MaxNumOfAccounts: values.log2MaxNumOfAccounts,
-                accountsDriveStartIndex: BigInt(values.accountsDriveStartIndex),
+                accountsDriveStartIndex:
+                    parseUint64(values.accountsDriveStartIndex) ?? 0n,
                 withdrawalOutputBuilder:
                     values.withdrawalOutputBuilder &&
                     isAddress(values.withdrawalOutputBuilder)
@@ -570,11 +595,10 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
                             disabled={deployed}
                             size="md"
                         />
-                        <NumberInput
+                        <TextInput
                             {...form.getInputProps("accountsDriveStartIndex")}
                             label="Accounts drive start index"
-                            min={0}
-                            allowDecimal={false}
+                            description="Decimal or hexadecimal (0x-prefixed)"
                             disabled={deployed}
                             size="md"
                         />

--- a/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
+++ b/apps/web/components/Deploy/SelfHosted/DeploySelfHosted.tsx
@@ -4,8 +4,10 @@ import {
     Button,
     CopyButton,
     Group,
+    Loader,
     NumberInput,
     ScrollArea,
+    SegmentedControl,
     SimpleGrid,
     Stack,
     Text,
@@ -14,7 +16,7 @@ import {
     Title,
     Tooltip,
 } from "@mantine/core";
-import { useForm } from "@mantine/form";
+import { type GetInputPropsReturnType, useForm } from "@mantine/form";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import {
     IconCheck,
@@ -44,14 +46,19 @@ import {
     optimismSepolia,
     sepolia,
 } from "viem/chains";
-import { useAccount, useWaitForTransactionReceipt } from "wagmi";
+import { useAccount, useBytecode, useWaitForTransactionReceipt } from "wagmi";
 
 import {
     dataAvailabilityAbi,
     inputBoxAddress,
+    useReadErc20Symbol,
     useReadSelfHostedApplicationFactoryCalculateAddresses,
+    useReadUsdWithdrawalOutputBuilderFactoryCalculateUsdWithdrawalOutputBuilderAddress,
     useSimulateSelfHostedApplicationFactoryDeployContracts,
+    useSimulateUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder,
+    usdWithdrawalOutputBuilderFactoryAddress,
     useWriteSelfHostedApplicationFactoryDeployContracts,
+    useWriteUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder,
 } from "../../../src/contracts";
 import MachineInstructions from "../MachineInstructions";
 import WalletInstructions from "./WalletInstructions";
@@ -81,6 +88,257 @@ const dataAvailability = encodeFunctionData({
     functionName: "InputBox",
     args: [inputBoxAddress],
 });
+
+// A fixed salt is fine here: USD withdrawal output builders are stateless, so a given
+// token always maps to the same builder address. This lets anyone reuse a builder that
+// was already deployed for that token instead of paying to deploy a duplicate.
+const USD_BUILDER_SALT = zeroHash;
+
+const hasCode = (code?: string) => !!code && code !== "0x";
+
+type WithdrawalOutputBuilderProps = {
+    disabled: boolean;
+    // input props for the manual-address field (an already-deployed builder)
+    inputProps: GetInputPropsReturnType;
+    // reports the resolved builder address back to the parent form
+    onChange: (value: string) => void;
+};
+
+// Lets the user either point at an existing withdrawal output builder or deploy one for
+// an ERC-20 token through the UsdWithdrawalOutputBuilderFactory. Either way the resolved
+// builder address is fed into the parent form's `withdrawalOutputBuilder` field.
+const WithdrawalOutputBuilder: FC<WithdrawalOutputBuilderProps> = ({
+    disabled,
+    inputProps,
+    onChange,
+}) => {
+    const [mode, setMode] = useState<"existing" | "usd">("existing");
+    const [token, setToken] = useState("");
+
+    const tokenAddress = isAddress(token) ? getAddress(token) : undefined;
+
+    // is the factory deployed on the connected chain? (supported testnets only)
+    const factoryCode = useBytecode({
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+    });
+    const factoryAvailable = hasCode(factoryCode.data);
+
+    // token symbol, shown as a confirmation that the address is a real ERC-20
+    const symbol = useReadErc20Symbol({
+        address: tokenAddress,
+        query: { enabled: mode === "usd" && !!tokenAddress },
+    });
+
+    // deterministic address of the builder for this token
+    const computed =
+        useReadUsdWithdrawalOutputBuilderFactoryCalculateUsdWithdrawalOutputBuilderAddress(
+            {
+                args: tokenAddress
+                    ? [tokenAddress, USD_BUILDER_SALT]
+                    : undefined,
+                query: {
+                    enabled:
+                        mode === "usd" && !!tokenAddress && factoryAvailable,
+                },
+            },
+        );
+    const builderAddress = computed.data;
+
+    // has the builder for this token already been deployed?
+    const builderCode = useBytecode({
+        address: builderAddress,
+        query: { enabled: !!builderAddress },
+    });
+    const builderExists = hasCode(builderCode.data);
+
+    // simulate + execute the factory deployment (only when not already deployed)
+    const simulate =
+        useSimulateUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder(
+            {
+                args: tokenAddress
+                    ? [tokenAddress, USD_BUILDER_SALT]
+                    : undefined,
+                query: {
+                    enabled:
+                        mode === "usd" &&
+                        !!tokenAddress &&
+                        factoryAvailable &&
+                        !!builderAddress &&
+                        !builderExists,
+                },
+            },
+        );
+    const execute =
+        useWriteUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder();
+    const receipt = useWaitForTransactionReceipt({ hash: execute.data });
+
+    // refresh the builder bytecode once the deployment is mined
+    // biome-ignore lint/correctness/useExhaustiveDependencies: only react to mined tx
+    useEffect(() => {
+        if (receipt.isSuccess) {
+            builderCode.refetch();
+        }
+    }, [receipt.isSuccess]);
+
+    // feed the resolved builder address into the parent form. Only report it once the
+    // contract actually exists so the application never references a missing builder.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: onChange identity is stable enough
+    useEffect(() => {
+        if (mode === "usd") {
+            onChange(builderExists && builderAddress ? builderAddress : "");
+        }
+    }, [mode, builderExists, builderAddress]);
+
+    const changeMode = (value: string) => {
+        // each mode manages the field itself; reset the resolved value on switch
+        setMode(value as "existing" | "usd");
+        onChange("");
+    };
+
+    return (
+        <Stack gap="xs">
+            <div>
+                <Text fw={500} size="sm">
+                    Withdrawal output builder
+                </Text>
+                <Text size="xs" c="dimmed">
+                    Contract that formats withdrawal vouchers. Provide an
+                    existing implementation, or deploy one for an ERC-20 token
+                    using the USD withdrawal output builder factory.
+                </Text>
+            </div>
+            <SegmentedControl
+                value={mode}
+                onChange={changeMode}
+                disabled={disabled}
+                data={[
+                    { label: "Existing address", value: "existing" },
+                    { label: "Deploy for ERC-20 token", value: "usd" },
+                ]}
+            />
+            {mode === "existing" ? (
+                <TextInput
+                    {...inputProps}
+                    placeholder={zeroAddress}
+                    disabled={disabled}
+                    size="md"
+                />
+            ) : (
+                <Stack gap="xs">
+                    {!factoryAvailable && (
+                        <Alert
+                            variant="light"
+                            color="yellow"
+                            icon={<IconExclamationCircle />}
+                        >
+                            The USD withdrawal output builder factory is not
+                            available on the connected network. It is deployed
+                            on supported testnets only.
+                        </Alert>
+                    )}
+                    <TextInput
+                        label="ERC-20 token address"
+                        description="The USD-like ERC-20 token the builder will handle"
+                        placeholder={zeroAddress}
+                        value={token}
+                        onChange={(event) =>
+                            setToken(event.currentTarget.value)
+                        }
+                        error={
+                            token && !tokenAddress ? "Invalid address" : null
+                        }
+                        disabled={disabled || !factoryAvailable}
+                        size="md"
+                        rightSection={
+                            symbol.isLoading ? <Loader size="xs" /> : null
+                        }
+                    />
+                    {mode === "usd" && tokenAddress && symbol.data && (
+                        <Text size="xs" c="dimmed">
+                            Detected token: {symbol.data}
+                        </Text>
+                    )}
+                    {tokenAddress && factoryAvailable && (
+                        <>
+                            <TextInput
+                                label="Builder address"
+                                description={
+                                    builderExists
+                                        ? "This builder is already deployed and will be used."
+                                        : "Deploy the builder to use this address."
+                                }
+                                value={builderAddress ?? ""}
+                                readOnly
+                                size="md"
+                                ff="mono"
+                            />
+                            {simulate.isError && (
+                                <ScrollArea>
+                                    <Alert
+                                        title={simulate.error?.name}
+                                        variant="light"
+                                        color="red"
+                                        icon={<IconExclamationCircle />}
+                                        ff="mono"
+                                    >
+                                        {simulate.error?.message}
+                                    </Alert>
+                                </ScrollArea>
+                            )}
+                            {execute.isError && (
+                                <ScrollArea>
+                                    <Alert
+                                        title={execute.error?.name}
+                                        variant="light"
+                                        color="red"
+                                        icon={<IconExclamationCircle />}
+                                        ff="mono"
+                                    >
+                                        {execute.error?.message}
+                                    </Alert>
+                                </ScrollArea>
+                            )}
+                            {builderExists ? (
+                                <Alert
+                                    variant="light"
+                                    color="green"
+                                    icon={<IconInfoCircle />}
+                                >
+                                    Builder ready. It will be used for this
+                                    application's withdrawals.
+                                </Alert>
+                            ) : (
+                                <Group>
+                                    <Button
+                                        variant="light"
+                                        disabled={
+                                            !simulate.data?.request || disabled
+                                        }
+                                        loading={
+                                            simulate.isLoading ||
+                                            execute.isPending ||
+                                            (execute.isSuccess &&
+                                                receipt.isLoading)
+                                        }
+                                        onClick={() => {
+                                            if (simulate.data) {
+                                                execute.writeContract(
+                                                    simulate.data.request,
+                                                );
+                                            }
+                                        }}
+                                    >
+                                        Deploy builder
+                                    </Button>
+                                </Group>
+                            )}
+                        </>
+                    )}
+                </Stack>
+            )}
+        </Stack>
+    );
+};
 
 type DeploySelfHostedProps = {
     authorityOwner?: string;
@@ -294,13 +552,6 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
                             disabled={deployed}
                             size="md"
                         />
-                        <TextInput
-                            {...form.getInputProps("withdrawalOutputBuilder")}
-                            label="Withdrawal output builder"
-                            placeholder={zeroAddress}
-                            disabled={deployed}
-                            size="md"
-                        />
                         <NumberInput
                             {...form.getInputProps("log2LeavesPerAccount")}
                             label="log2 leaves per account"
@@ -328,6 +579,15 @@ const DeploySelfHosted: FC<DeploySelfHostedProps> = (props) => {
                             size="md"
                         />
                     </SimpleGrid>
+                    <WithdrawalOutputBuilder
+                        disabled={deployed}
+                        inputProps={form.getInputProps(
+                            "withdrawalOutputBuilder",
+                        )}
+                        onChange={(value) =>
+                            form.setFieldValue("withdrawalOutputBuilder", value)
+                        }
+                    />
                 </Stack>
             </Timeline.Item>
             <Timeline.Item title="Deploy" pb="lg">

--- a/apps/web/src/contracts.ts
+++ b/apps/web/src/contracts.ts
@@ -509,6 +509,103 @@ export const selfHostedApplicationFactoryConfig = {
 } as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// usdWithdrawalOutputBuilderFactory
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const usdWithdrawalOutputBuilderFactoryAbi = [
+    {
+        type: 'constructor',
+        inputs: [
+            {
+                name: 'safeErc20Transfer',
+                internalType: 'contract ISafeERC20Transfer',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [
+            { name: 'token', internalType: 'contract IERC20', type: 'address' },
+            { name: 'salt', internalType: 'bytes32', type: 'bytes32' },
+        ],
+        name: 'calculateUsdWithdrawalOutputBuilderAddress',
+        outputs: [
+            {
+                name: 'usdWithdrawalOutputBuilderAddress',
+                internalType: 'address',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'getSafeErc20Transfer',
+        outputs: [
+            {
+                name: 'safeErc20Transfer',
+                internalType: 'contract ISafeERC20Transfer',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'view',
+    },
+    {
+        type: 'function',
+        inputs: [
+            { name: 'token', internalType: 'contract IERC20', type: 'address' },
+            { name: 'salt', internalType: 'bytes32', type: 'bytes32' },
+        ],
+        name: 'newUsdWithdrawalOutputBuilder',
+        outputs: [
+            {
+                name: 'usdWithdrawalOutputBuilder',
+                internalType: 'contract IUsdWithdrawalOutputBuilder',
+                type: 'address',
+            },
+        ],
+        stateMutability: 'nonpayable',
+    },
+    {
+        type: 'function',
+        inputs: [],
+        name: 'version',
+        outputs: [
+            { name: 'major', internalType: 'uint64', type: 'uint64' },
+            { name: 'minor', internalType: 'uint64', type: 'uint64' },
+            { name: 'patch', internalType: 'uint64', type: 'uint64' },
+            { name: 'preRelease', internalType: 'string', type: 'string' },
+            { name: 'buildMetadata', internalType: 'string', type: 'string' },
+        ],
+        stateMutability: 'pure',
+    },
+    {
+        type: 'event',
+        anonymous: false,
+        inputs: [
+            {
+                name: 'usdWithdrawalOutputBuilder',
+                internalType: 'contract IUsdWithdrawalOutputBuilder',
+                type: 'address',
+                indexed: false,
+            },
+        ],
+        name: 'UsdWithdrawalOutputBuilderCreated',
+    },
+] as const
+
+export const usdWithdrawalOutputBuilderFactoryAddress =
+    '0xdB4EC04a2792A04cF7421f99A70F624681dd8e50' as const
+
+export const usdWithdrawalOutputBuilderFactoryConfig = {
+    address: usdWithdrawalOutputBuilderFactoryAddress,
+    abi: usdWithdrawalOutputBuilderFactoryAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // React
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -887,4 +984,100 @@ export const useSimulateSelfHostedApplicationFactoryDeployContracts =
         abi: selfHostedApplicationFactoryAbi,
         address: selfHostedApplicationFactoryAddress,
         functionName: 'deployContracts',
+    })
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__
+ */
+export const useReadUsdWithdrawalOutputBuilderFactory =
+    /*#__PURE__*/ createUseReadContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+    })
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `functionName` set to `"calculateUsdWithdrawalOutputBuilderAddress"`
+ */
+export const useReadUsdWithdrawalOutputBuilderFactoryCalculateUsdWithdrawalOutputBuilderAddress =
+    /*#__PURE__*/ createUseReadContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        functionName: 'calculateUsdWithdrawalOutputBuilderAddress',
+    })
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `functionName` set to `"getSafeErc20Transfer"`
+ */
+export const useReadUsdWithdrawalOutputBuilderFactoryGetSafeErc20Transfer =
+    /*#__PURE__*/ createUseReadContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        functionName: 'getSafeErc20Transfer',
+    })
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `functionName` set to `"version"`
+ */
+export const useReadUsdWithdrawalOutputBuilderFactoryVersion =
+    /*#__PURE__*/ createUseReadContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        functionName: 'version',
+    })
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__
+ */
+export const useWriteUsdWithdrawalOutputBuilderFactory =
+    /*#__PURE__*/ createUseWriteContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+    })
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `functionName` set to `"newUsdWithdrawalOutputBuilder"`
+ */
+export const useWriteUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder =
+    /*#__PURE__*/ createUseWriteContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        functionName: 'newUsdWithdrawalOutputBuilder',
+    })
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__
+ */
+export const useSimulateUsdWithdrawalOutputBuilderFactory =
+    /*#__PURE__*/ createUseSimulateContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+    })
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `functionName` set to `"newUsdWithdrawalOutputBuilder"`
+ */
+export const useSimulateUsdWithdrawalOutputBuilderFactoryNewUsdWithdrawalOutputBuilder =
+    /*#__PURE__*/ createUseSimulateContract({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        functionName: 'newUsdWithdrawalOutputBuilder',
+    })
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__
+ */
+export const useWatchUsdWithdrawalOutputBuilderFactoryEvent =
+    /*#__PURE__*/ createUseWatchContractEvent({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+    })
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link usdWithdrawalOutputBuilderFactoryAbi}__ and `eventName` set to `"UsdWithdrawalOutputBuilderCreated"`
+ */
+export const useWatchUsdWithdrawalOutputBuilderFactoryUsdWithdrawalOutputBuilderCreatedEvent =
+    /*#__PURE__*/ createUseWatchContractEvent({
+        abi: usdWithdrawalOutputBuilderFactoryAbi,
+        address: usdWithdrawalOutputBuilderFactoryAddress,
+        eventName: 'UsdWithdrawalOutputBuilderCreated',
     })

--- a/apps/web/wagmi.config.ts
+++ b/apps/web/wagmi.config.ts
@@ -11,12 +11,6 @@ import { type Abi, type Address, erc20Abi } from "viem";
 // across every chain, so a single address from the devnet deployment applies everywhere.
 const { contracts } = devnet;
 
-// The USD withdrawal output builder factory is deployed at the same deterministic
-// address on all supported testnets. It is not part of the devnet deployment file,
-// so its address is hardcoded here.
-const usdWithdrawalOutputBuilderFactoryAddress =
-    "0xdB4EC04a2792A04cF7421f99A70F624681dd8e50" as Address;
-
 const config = defineConfig({
     out: "src/contracts.ts",
     contracts: [
@@ -27,7 +21,7 @@ const config = defineConfig({
         {
             name: "usdWithdrawalOutputBuilderFactory",
             abi: usdWithdrawalOutputBuilderFactory.abi as Abi,
-            address: usdWithdrawalOutputBuilderFactoryAddress,
+            address: contracts.UsdWithdrawalOutputBuilderFactory.address as Address,
         },
         {
             name: "selfHostedApplicationFactory",

--- a/apps/web/wagmi.config.ts
+++ b/apps/web/wagmi.config.ts
@@ -1,11 +1,8 @@
-import devnet from "@cartesi/devnet/deployments/anvil.json" with {
-    type: "json",
-};
+import devnet from "@cartesi/devnet/deployments/anvil.json" with { type: "json" };
 import dataAvailability from "@cartesi/rollups/out/DataAvailability.sol/DataAvailability.json" with { type: "json" };
-import inputBox from "@cartesi/rollups/out/InputBox.sol/InputBox.json" with {
-    type: "json",
-};
+import inputBox from "@cartesi/rollups/out/InputBox.sol/InputBox.json" with { type: "json" };
 import selfHostedApplicationFactory from "@cartesi/rollups/out/SelfHostedApplicationFactory.sol/SelfHostedApplicationFactory.json" with { type: "json" };
+import usdWithdrawalOutputBuilderFactory from "@cartesi/rollups/out/UsdWithdrawalOutputBuilderFactory.sol/UsdWithdrawalOutputBuilderFactory.json" with { type: "json" };
 import { type Config, defineConfig } from "@wagmi/cli";
 import { react } from "@wagmi/cli/plugins";
 import { type Abi, type Address, erc20Abi } from "viem";
@@ -14,12 +11,23 @@ import { type Abi, type Address, erc20Abi } from "viem";
 // across every chain, so a single address from the devnet deployment applies everywhere.
 const { contracts } = devnet;
 
+// The USD withdrawal output builder factory is deployed at the same deterministic
+// address on all supported testnets. It is not part of the devnet deployment file,
+// so its address is hardcoded here.
+const usdWithdrawalOutputBuilderFactoryAddress =
+    "0xdB4EC04a2792A04cF7421f99A70F624681dd8e50" as Address;
+
 const config = defineConfig({
     out: "src/contracts.ts",
     contracts: [
         {
             name: "erc20",
             abi: erc20Abi,
+        },
+        {
+            name: "usdWithdrawalOutputBuilderFactory",
+            abi: usdWithdrawalOutputBuilderFactory.abi as Abi,
+            address: usdWithdrawalOutputBuilderFactoryAddress,
         },
         {
             name: "selfHostedApplicationFactory",


### PR DESCRIPTION
The withdrawal configuration on the self-hosted deploy page now lets users
either paste the address of an existing IWithdrawalOutputBuilder
implementation, or deploy a USD withdrawal output builder for an ERC-20
token through the UsdWithdrawalOutputBuilderFactory.

- Generate wagmi hooks for the factory (address 0xdB4EC04a...8e50, deployed
  on supported testnets) via wagmi.config.ts + codegen.
- Add a WithdrawalOutputBuilder sub-component with an "Existing address" /
  "Deploy for ERC-20 token" toggle. The factory path computes the
  deterministic builder address, reuses it when already deployed, and
  otherwise offers a one-click deploy before feeding the resolved address
  into the deploy form.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FaMizE6PgypQGWe7NJZNE5